### PR TITLE
Added http request response handler

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -25,7 +25,7 @@ router.get(
 
       if (!IDEFIX_BANID_DISTRICS.includes(districtID)) {
         await legacyCompose(districtID);
-        console.log('Legacy compose done')
+        console.log("Legacy compose done");
       } else {
         const revision = await getRevisionFromDistrictID(districtID);
         const revisionFileText = await getRevisionFileText(revision._id);

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,31 +1,71 @@
 /// <reference lib="dom" />
+
 const BAN_API_URL = process.env.BAN_API_URL || "";
 const BAN_API_TOKEN = process.env.BAN_API_TOKEN || "";
 const API_DEPOT_URL = process.env.API_DEPOT_URL || "";
 
 export const legacyCompose = async (districtID: string) => {
-  const response = await fetch(
-    `${BAN_API_URL}/ban/communes/${districtID}/compose`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Token ${BAN_API_TOKEN}`,
-      },
-    }
-  );
-  return response.json();
+  try {
+    const response = await fetch(
+      `${BAN_API_URL}/ban/communes/${districtID}/compose`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${BAN_API_TOKEN}`,
+        },
+      }
+    );
+    return await HandleHTTPResponse(response);
+  } catch (error) {
+    const { message } = error as Error;
+    throw new Error(`Ban legacy API - ${message}`);
+  }
 };
 
 export const getRevisionFromDistrictID = async (codeCommune: string) => {
-  const response = await fetch(
-    `${API_DEPOT_URL}/communes/${codeCommune}/current-revision`
-  );
-  return response.json();
+  try {
+    const response = await fetch(
+      `${API_DEPOT_URL}/communes/${codeCommune}/current-revision`
+    );
+    return await HandleHTTPResponse(response);
+  } catch (error) {
+    const { message } = error as Error;
+    throw new Error(`Deposit API - ${message}`);
+  }
 };
 
 export const getRevisionFileText = async (revisionId: string) => {
-  const response = await fetch(
-    `${API_DEPOT_URL}/revisions/${revisionId}/files/bal/download`
-  );
-  return response.text();
+  try {
+    const response = await fetch(
+      `${API_DEPOT_URL}/revisions/${revisionId}/files/bal/download`
+    );
+    return await HandleHTTPResponse(response);
+  } catch (error) {
+    const { message } = error as Error;
+    throw new Error(`Deposit API - ${message}`);
+  }
+};
+
+// Handlers
+
+const HandleHTTPResponse = async (response: Response): Promise<any> => {
+  const contentType = response.headers.get("content-type");
+
+  if (!response.ok) {
+    let error;
+    if (contentType && contentType.includes("application/json")) {
+      const data = await response.json();
+      error = new Error(data.message || response.statusText);
+    } else {
+      const text = await response.text();
+      error = new Error(text || response.statusText);
+    }
+    throw error;
+  }
+
+  if (contentType && contentType.includes("application/json")) {
+    return response.json();
+  } else {
+    return response.text();
+  }
 };


### PR DESCRIPTION
I. Context
No HTTP request handler is present in the current code

II. Enhancements
We have added a new http request response handler that : 
- throw error data to the main route catch if response not ok
- return the right data (json or text) depending on the content-type response header

III. Examples 
Here are some examples of error we get with the handler : 

One of the API called is not responding : 

Example n°1 : 
{
    "date": "2023-04-27T15:39:27.435Z",
    "status": "error",
    "message": "Deposit API - fetch failed",
    "response": {}
}

Example n°2 : 
{
    "date": "2023-04-27T15:41:08.861Z",
    "status": "error",
    "message": "Ban legacy API - fetch failed",
    "response": {}
}

Error data returned by one of the API used : 

Example n°1 : 
{
    "date": "2023-04-27T15:22:59.989Z",
    "status": "error",
    "message": "Ban legacy API - Commune non présente dans la BAN",
    "response": {}
}

Example n°2 : 
{
    "date": "2023-04-27T15:24:38.087Z",
    "status": "error",
    "message": "Deposit API - Le code commune n’existe pas",
    "response": {}
}