### PR TITLE
Updated address and toponym schema to fit ban-plateforme schemas

### DIFF
--- a/src/bal-converter/index.ts
+++ b/src/bal-converter/index.ts
@@ -43,9 +43,10 @@ const balAddrToBanAddr = (
   return {
     ...(oldBanAddress || {}),
     id: banID,
-    codeCommune: balAdresse.commune_insee,
-    idVoie: banCommonTopoID,
-    numero: balAdresse.numero,
+    districtID: balAdresse.commune_insee,
+    commonToponymID: banCommonTopoID,
+    number: balAdresse.numero,
+    suffix: balAdresse.suffixe,
     positions: [
       // Old positions
       ...(oldBanAddress?.positions || []),
@@ -57,7 +58,9 @@ const balAddrToBanAddr = (
         },
       },
     ],
-    dateMAJ: balAdresse.date_der_maj,
+    parcels: balAdresse.cad_parcelles,
+    certified: balAdresse.certification_commune,
+    updateDate: balAdresse.date_der_maj,
   };
 };
 
@@ -81,7 +84,7 @@ const balTopoToBanTopo = (
   return {
     ...(oldBanCommonToponym || {}),
     id: banCommonTopoID,
-    codeCommune: balAdresse.commune_insee,
+    districtID: balAdresse.commune_insee,
     label: Object.entries(labels).map(([isoCode, value]) => ({
       isoCode,
       value,
@@ -91,7 +94,8 @@ const balTopoToBanTopo = (
       type: "Point",
       coordinates: [balAdresse.long, balAdresse.lat],
     },
-    dateMAJ: balAdresse.date_der_maj,
+    parcels: balAdresse.cad_parcelles,
+    updateDate: balAdresse.date_der_maj,
   };
 };
 
@@ -104,7 +108,7 @@ const balToBan = (bal: Bal): Ban => {
         balAdresse,
         acc.commonToponyms?.[banCommonTopoID]
       );
-      const districtID = banIdContent.codeCommune;
+      const districtID = banIdContent.districtID;
       return {
         ...acc,
         districtID,

--- a/src/bal-converter/utils.ts
+++ b/src/bal-converter/utils.ts
@@ -41,8 +41,8 @@ export const balCSVlegacy2balCSV = (balCSVlegacy: Bal): Bal => {
       cle_interop: cleInterop,
       ...balAdresseRest
     }: BalAdresse) => {
-      const [, idVoieLegacy, idAddrLegacy] = cleInterop.split("_");
-      const idVoie = `00000000-0000-4000-9000-${idVoieLegacy.padStart(
+      const [, commonToponymIDLegacy, idAddrLegacy] = cleInterop.split("_");
+      const commonToponymID = `00000000-0000-4000-9000-${commonToponymIDLegacy.padStart(
         12,
         "0"
       )}`;
@@ -51,9 +51,9 @@ export const balCSVlegacy2balCSV = (balCSVlegacy: Bal): Bal => {
           ? `00000000-${idAddrLegacy.padStart(
               4,
               "0"
-            )}-4aaa-9aaa-${idVoieLegacy.padStart(12, "a")}`
+            )}-4aaa-9aaa-${commonToponymIDLegacy.padStart(12, "a")}`
           : "";
-      const uidAdresse = uidAdresseLegacy || `${idAddr}/${idVoie}`;
+      const uidAdresse = uidAdresseLegacy || `${idAddr}/${commonToponymID}`;
       return {
         uid_adresse: uidAdresse,
         cle_interop: cleInterop,

--- a/src/ban-api/index.ts
+++ b/src/ban-api/index.ts
@@ -35,11 +35,11 @@ export const legacyCompose = async (districtID: string) => {
 };
 
 export const getAddressIdsReport = async (
-  codeCommune: DistrictInseeID,
+  districtID: DistrictInseeID,
   addressIDs: BanID[]
 ) => {
   try {
-    const body = JSON.stringify({ codeCommune, addressIDs });
+    const body = JSON.stringify({ districtID, addressIDs });
     const response = await fetch(`${BAN_API_URL}/address/delta-report`, {
       method: "POST",
       headers: defaultHeader,
@@ -100,11 +100,11 @@ export const deleteAddresses = async (ids: BanID[]) => {
 };
 
 export const getCommonToponymIdsReport = async (
-  codeCommune: DistrictInseeID,
+  districtID: DistrictInseeID,
   commonToponymIDs: BanID[]
 ) => {
   try {
-    const body = JSON.stringify({ codeCommune, commonToponymIDs });
+    const body = JSON.stringify({ districtID, commonToponymIDs });
     const response = await fetch(`${BAN_API_URL}/common-toponym/delta-report`, {
       method: "POST",
       headers: defaultHeader,

--- a/src/types/ban-types.d.ts
+++ b/src/types/ban-types.d.ts
@@ -19,16 +19,19 @@ export type Position = {
 };
 
 export type BanDistrict = {
-  codeCommune: DistrictInseeID; // code INSEE de la commune
-  nomCommune: string; // nom de la commune
-  dateMAJ: DateISO8601; // date de mise à jour de la commune
+  districtID: DistrictInseeID; // code INSEE de la commune
+  label: {
+    isoCode: LangISO639v3; // code ISO de la langue
+    value: string; // nom de la voie
+  }[];
+  updateDate: DateISO8601; // date de mise à jour de la commune
 };
 
 export type BanDistricts = BanDistrict[];
 
 export type BanCommonToponym = {
   id: BanCommonTopoID; // identifiant unique de la voie
-  codeCommune: DistrictInseeID; // code INSEE de la commune
+  districtID: DistrictInseeID; // code INSEE de la commune
   label: {
     isoCode: LangISO639v3; // code ISO de la langue
     value: string; // nom de la voie
@@ -40,21 +43,22 @@ export type BanCommonToponym = {
     type: "Point";
     coordinates: [number, number, number?];
   };
-  dateMAJ: DateISO8601; // date de mise à jour de la voie
+  parcels?: string[]; // parcelles cadastrales de la voie
+  updateDate: DateISO8601; // date de mise à jour de la voie
 };
 
 export type BanCommonToponyms = BanCommonToponym[];
 
 export type BanAddress = {
   id: BanID; // identifiant unique de l'adresse
-  codeCommune: DistrictInseeID; // code INSEE de la commune
-  idVoie: BanCommonTopoID; // identifiant unique de la voie
-  numero: number; // numéro de l'adresse
-  suffixe?: string;
+  districtID: DistrictInseeID; // code INSEE de la commune
+  commonToponymID: BanCommonTopoID; // identifiant unique de la voie
+  number: number; // numéro de l'adresse
+  suffix?: string;
   positions: Position[]; // positions géographiques de l'adresse
-  parcelles?: string[]; // parcelles cadastrales de l'adresse // TODO: Verrifier que les parcelles ne soit pas par position et non par adresse
-  certifie?: boolean;
-  dateMAJ: DateISO8601; // date de mise à jour de l'adresse
+  parcels?: string[]; // parcelles cadastrales de l'adresse // TODO: Verrifier que les parcelles ne soit pas par position et non par adresse
+  certified?: boolean;
+  updateDate: DateISO8601; // date de mise à jour de l'adresse
 };
 
 export type BanAddresses = BanAddress[];


### PR DESCRIPTION
This PR aims to rename schema fields for address and common toponym to fit english standards. As a consequence, here are the new schemas : 

1. address schema : 
```
id: BanID; // identifiant unique de l'adresse
districtID: DistrictInseeID; // code INSEE de la commune
commonToponymID: BanCommonTopoID; // identifiant unique de la voie
number: number; // numéro de l'adresse
suffix?: string;
positions: Position[]; // positions géographiques de l'adresse
parcels?: string[]; // parcelles cadastrales de l'adresse // TODO: Verrifier que les parcelles ne soit pas par position et non par adresse
certified?: boolean;
updateDate: DateISO8601; // date de mise à jour de l'adresse
```

2. commonToponym schema : 
```
id: BanCommonTopoID; // identifiant unique de la voie
districtID: DistrictInseeID; // code INSEE de la commune
label: {
  isoCode: LangISO639v3; // code ISO de la langue
  value: string; // nom de la voie
}[];
type: {
  value: ToponymType; // type de la voie (voie, lieu-dit, etc.)
};
geometry: {
  type: "Point";
  coordinates: [number, number, number?];
};
parcels?: string[]; // parcelles cadastrales de la voie
updateDate: DateISO8601; // date de mise à jour de la voie
```
