### PR TITLE
Fix ban api url in env.sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 IDEFIX_ADMIN_TOKENS=IDEFIX_ADMIN_TOKEN_1,IDEFIX_ADMIN_TOKEN_2
 IDEFIX_BANID_DISTRICTS=IDEFIX_BANID_DISTRICTS_1,IDEFIX_BANID_DISTRICTS_2
-BAN_API_URL=https://plateforme.adresse.data.gouv.fr
+BAN_API_URL=https://plateforme.adresse.data.gouv.fr/api
 BAN_API_TOKEN=
 API_DEPOT_URL=API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot


### PR DESCRIPTION
I. Context

BAN API URL has been changed from `https://plateforme.adresse.data.gouv.fr/` to `https://plateforme.adresse.data.gouv.fr/api`

II. Enhancement

BAN_API_URL has been modified to follow new URL. 
All .env files have to be updated (local and production)