### PR TITLE
Updated address and common toponym schemas

### DIFF
--- a/data-mock/adresses-21286_cocorico.json
+++ b/data-mock/adresses-21286_cocorico.json
@@ -78,7 +78,7 @@
     "y": 6854310.41,
     "long": 1.086279,
     "lat": 48.773553,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -99,7 +99,7 @@
     "y": 6854342.28,
     "long": 1.08586,
     "lat": 48.773833,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -120,7 +120,7 @@
     "y": 6854365.24,
     "long": 1.085574,
     "lat": 48.774035,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -439,7 +439,7 @@
     "y": 6854307.15,
     "long": 1.07932,
     "lat": 48.773412,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -460,7 +460,7 @@
     "y": 6854280.12,
     "long": 1.078832,
     "lat": 48.773161,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -481,7 +481,7 @@
     "y": 6854326.7,
     "long": 1.079699,
     "lat": 48.773594,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -502,7 +502,7 @@
     "y": 6852668.52,
     "long": 1.088235,
     "lat": 48.758813,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -523,7 +523,7 @@
     "y": 6852865.29,
     "long": 1.071305,
     "lat": 48.760311,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -544,7 +544,7 @@
     "y": 6851883.59,
     "long": 1.071619,
     "lat": 48.751484,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -565,7 +565,7 @@
     "y": 6855705.13,
     "long": 1.060016,
     "lat": 48.785677,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -586,7 +586,7 @@
     "y": 6854169.7,
     "long": 1.081033,
     "lat": 48.772203,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -607,7 +607,7 @@
     "y": 6854091.39,
     "long": 1.063471,
     "lat": 48.771215,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -628,7 +628,7 @@
     "y": 6852964.76,
     "long": 1.061001,
     "lat": 48.761039,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-08-31T00:00:00.000Z",
     "certification_commune": false
@@ -649,7 +649,7 @@
     "y": 6852856.45,
     "long": 1.067195,
     "lat": 48.760165,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-03T00:00:00.000Z",
     "certification_commune": false
@@ -670,7 +670,7 @@
     "y": 6853815.12,
     "long": 1.060606,
     "lat": 48.768683,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-13T00:00:00.000Z",
     "certification_commune": false
@@ -691,7 +691,7 @@
     "y": 6852845.39,
     "long": 1.06278,
     "lat": 48.759994,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -712,7 +712,7 @@
     "y": 6853495.37,
     "long": 1.077283,
     "lat": 48.766076,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2023-01-13T00:00:00.000Z",
     "certification_commune": false

--- a/data-mock/adresses-21286_cocorico.legacy.json
+++ b/data-mock/adresses-21286_cocorico.legacy.json
@@ -78,7 +78,7 @@
     "y": 6854310.41,
     "long": 1.086279,
     "lat": 48.773553,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": true
@@ -99,7 +99,7 @@
     "y": 6854342.28,
     "long": 1.08586,
     "lat": 48.773833,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": true
@@ -120,7 +120,7 @@
     "y": 6854365.24,
     "long": 1.085574,
     "lat": 48.774035,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": true
@@ -445,7 +445,7 @@
     "y": 6854307.15,
     "long": 1.07932,
     "lat": 48.773412,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": true
@@ -466,7 +466,7 @@
     "y": 6854280.12,
     "long": 1.078832,
     "lat": 48.773161,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": true
@@ -487,7 +487,7 @@
     "y": 6854326.7,
     "long": 1.079699,
     "lat": 48.773594,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": true
@@ -508,7 +508,7 @@
     "y": 6852668.52,
     "long": 1.088235,
     "lat": 48.758813,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -529,7 +529,7 @@
     "y": 6852865.29,
     "long": 1.071305,
     "lat": 48.760311,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -550,7 +550,7 @@
     "y": 6851883.59,
     "long": 1.071619,
     "lat": 48.751484,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -571,7 +571,7 @@
     "y": 6855705.13,
     "long": 1.060016,
     "lat": 48.785677,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -592,7 +592,7 @@
     "y": 6854169.7,
     "long": 1.081033,
     "lat": 48.772203,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -613,7 +613,7 @@
     "y": 6854091.39,
     "long": 1.063471,
     "lat": 48.771215,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -634,7 +634,7 @@
     "y": 6852964.76,
     "long": 1.061001,
     "lat": 48.761039,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-08-31T00:00:00.000Z",
     "certification_commune": false
@@ -655,7 +655,7 @@
     "y": 6852856.45,
     "long": 1.067195,
     "lat": 48.760165,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-03T00:00:00.000Z",
     "certification_commune": false
@@ -676,7 +676,7 @@
     "y": 6853815.12,
     "long": 1.060606,
     "lat": 48.768683,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-13T00:00:00.000Z",
     "certification_commune": false
@@ -697,7 +697,7 @@
     "y": 6852845.39,
     "long": 1.06278,
     "lat": 48.759994,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -718,7 +718,7 @@
     "y": 6853495.37,
     "long": 1.077283,
     "lat": 48.766076,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2023-01-13T00:00:00.000Z",
     "certification_commune": false

--- a/data-mock/adresses-21286_cocorico.partial.json
+++ b/data-mock/adresses-21286_cocorico.partial.json
@@ -78,7 +78,7 @@
     "y": 6854310.41,
     "long": 1.086279,
     "lat": 48.773553,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -99,7 +99,7 @@
     "y": 6854342.28,
     "long": 1.08586,
     "lat": 48.773833,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -120,7 +120,7 @@
     "y": 6854365.24,
     "long": 1.085574,
     "lat": 48.774035,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -439,7 +439,7 @@
     "y": 6854307.15,
     "long": 1.07932,
     "lat": 48.773412,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -460,7 +460,7 @@
     "y": 6854280.12,
     "long": 1.078832,
     "lat": 48.773161,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -481,7 +481,7 @@
     "y": 6854326.7,
     "long": 1.079699,
     "lat": 48.773594,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "commune",
     "date_der_maj": "2021-09-06T00:00:00.000Z",
     "certification_commune": false
@@ -502,7 +502,7 @@
     "y": 6852668.52,
     "long": 1.088235,
     "lat": 48.758813,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -523,7 +523,7 @@
     "y": 6852865.29,
     "long": 1.071305,
     "lat": 48.760311,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -544,7 +544,7 @@
     "y": 6851883.59,
     "long": 1.071619,
     "lat": 48.751484,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -565,7 +565,7 @@
     "y": 6855705.13,
     "long": 1.060016,
     "lat": 48.785677,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -586,7 +586,7 @@
     "y": 6854169.7,
     "long": 1.081033,
     "lat": 48.772203,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -607,7 +607,7 @@
     "y": 6854091.39,
     "long": 1.063471,
     "lat": 48.771215,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-07-03T00:00:00.000Z",
     "certification_commune": false
@@ -628,7 +628,7 @@
     "y": 6852964.76,
     "long": 1.061001,
     "lat": 48.761039,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2020-08-31T00:00:00.000Z",
     "certification_commune": false
@@ -649,7 +649,7 @@
     "y": 6852856.45,
     "long": 1.067195,
     "lat": 48.760165,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-03T00:00:00.000Z",
     "certification_commune": false
@@ -670,7 +670,7 @@
     "y": 6853815.12,
     "long": 1.060606,
     "lat": 48.768683,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-06-13T00:00:00.000Z",
     "certification_commune": false
@@ -691,7 +691,7 @@
     "y": 6852845.39,
     "long": 1.06278,
     "lat": 48.759994,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2022-08-23T00:00:00.000Z",
     "certification_commune": false
@@ -712,7 +712,7 @@
     "y": 6853495.37,
     "long": 1.077283,
     "lat": 48.766076,
-    "cad_parcelles": [""],
+    "cad_parcelles": [],
     "source": "",
     "date_der_maj": "2023-01-13T00:00:00.000Z",
     "certification_commune": false

--- a/src/bal-converter/helpers/__mocks__/fake-data.ts
+++ b/src/bal-converter/helpers/__mocks__/fake-data.ts
@@ -7,22 +7,24 @@ export const secondaryTopoIDs = [
   "cccccccc-1111-4aaa-9000-1234567890dd",
   "cccccccc-2222-4aaa-9000-1234567890ee",
 ];
+export const districtID = "dddddddd-0000-4aaa-9000-1234567890ff";
 
 const {
   addressID: addressIDKey,
   mainTopoID: mainTopoIDKey,
   secondaryTopoIDs: secondaryTopoIDsKey,
+  districtID: districtIDKey,
 } = idsIdentifierIndex;
 
-export const idSampleWithBanId = `${addressIDKey}${addrID}`;
+export const idSampleWithAddressId = `${addressIDKey}${addrID}`;
 export const idSampleWithMainTopoId = `${mainTopoIDKey}${mainTopoID}`;
 export const idSampleWithSecondaryTopoId = `${secondaryTopoIDsKey}${secondaryTopoIDs.join(
   "|"
 )}`;
-export const idSampleWithBanIdAndMainTopoId = `${addressIDKey}${addrID} ${mainTopoIDKey}${mainTopoID}`;
-export const idSampleWithBanIdAndSecondaryTopoId = `${addressIDKey}${addrID} ${secondaryTopoIDsKey}${secondaryTopoIDs.join(
-  "|"
-)}`;
-export const idSampleWithAllIds = `${addressIDKey}${addrID} ${mainTopoIDKey}${mainTopoID} ${secondaryTopoIDsKey}${secondaryTopoIDs.join(
-  "|"
-)}`;
+export const idSampleWithDistrictId = `${districtIDKey}${districtID}`;
+
+export const idSampleWithAddressIdAndMainTopoId = `${idSampleWithAddressId} ${idSampleWithMainTopoId}`;
+export const idSampleWithAddressIdAndSecondaryTopoId = `${idSampleWithAddressId} ${idSampleWithSecondaryTopoId}`;
+export const idSampleWithMainTopoIdAndDistrictId = `${idSampleWithMainTopoId} ${idSampleWithDistrictId}`;
+export const idSampleWithAllIds = 
+  `${idSampleWithAddressId} ${idSampleWithMainTopoId} ${idSampleWithSecondaryTopoId} ${idSampleWithDistrictId}`;

--- a/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
@@ -5,11 +5,11 @@ exports[`balAddrToBanAddr > should not consider as Ban Address 1`] = `undefined`
 exports[`balAddrToBanAddr > should return BanAddress with BanID and BanTopoID 1`] = `
 {
   "certified": true,
-  "commonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -19,22 +19,23 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID and BanTopoID 1`
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
   ],
+  "secondaryCommonToponymIDs": undefined,
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
 exports[`balAddrToBanAddr > should return BanAddress with BanID without BanTopoID 1`] = `
 {
   "certified": true,
-  "commonToponymID": undefined,
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "mainCommonToponymID": undefined,
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -44,22 +45,23 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID without BanTopoI
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
   ],
+  "secondaryCommonToponymIDs": undefined,
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
-exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID and other toponyms 1`] = `
+exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID, other toponyms and BanDistrictID 1`] = `
 {
   "certified": true,
-  "commonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "districtID": undefined,
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -69,22 +71,27 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID and o
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
   ],
+  "secondaryCommonToponymIDs": [
+    "cccccccc-0000-4aaa-9000-1234567890cc",
+    "cccccccc-1111-4aaa-9000-1234567890dd",
+    "cccccccc-2222-4aaa-9000-1234567890ee",
+  ],
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
 exports[`balAddrToBanAddr > should return BanAddress with BanTopoID 1`] = `
 {
   "certified": true,
-  "commonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "districtID": undefined,
   "id": undefined,
+  "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -94,22 +101,23 @@ exports[`balAddrToBanAddr > should return BanAddress with BanTopoID 1`] = `
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
   ],
+  "secondaryCommonToponymIDs": undefined,
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
 exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`] = `
 {
   "certified": true,
-  "commonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "districtID": undefined,
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -119,7 +127,7 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
     {
       "geometry": {
@@ -129,22 +137,27 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
         ],
         "type": "Point",
       },
-      "type": "autre",
+      "type": "other",
     },
   ],
+  "secondaryCommonToponymIDs": [
+    "cccccccc-0000-4aaa-9000-1234567890cc",
+    "cccccccc-1111-4aaa-9000-1234567890dd",
+    "cccccccc-2222-4aaa-9000-1234567890ee",
+  ],
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
 exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1`] = `
 {
   "certified": true,
-  "commonToponymID": undefined,
   "districtID": undefined,
   "id": undefined,
+  "mainCommonToponymID": undefined,
+  "meta": {},
   "number": 1,
-  "parcels": undefined,
   "positions": [
     {
       "geometry": {
@@ -154,10 +167,11 @@ exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1
         ],
         "type": "Point",
       },
-      "type": "entrée",
+      "type": "entrance",
     },
   ],
+  "secondaryCommonToponymIDs": undefined,
   "suffix": undefined,
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;

--- a/src/bal-converter/helpers/__snapshots__/bal-json-legacy-to-bal-json.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-json-legacy-to-bal-json.test.ts.snap
@@ -75,9 +75,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6853881.3,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_mz58hg_00029",
     "commune_deleguee_insee": "00000",
@@ -98,9 +96,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854310.41,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_mz58hg_00031",
     "commune_deleguee_insee": "00000",
@@ -121,9 +117,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854342.28,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_mz58hg_00033",
     "commune_deleguee_insee": "00000",
@@ -475,9 +469,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852855.2,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -498,9 +490,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854307.15,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -521,9 +511,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854280.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": true,
     "cle_interop": "21286_0085_00002",
     "commune_deleguee_insee": "00000",
@@ -544,9 +532,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854326.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_ty2whe_99999",
     "commune_deleguee_insee": "00000",
@@ -567,9 +553,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852668.52,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B019_99999",
     "commune_deleguee_insee": "00000",
@@ -590,9 +574,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852865.29,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_adckqc_99999",
     "commune_deleguee_insee": "00000",
@@ -613,9 +595,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6851883.59,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_t6v2h3_99999",
     "commune_deleguee_insee": "00000",
@@ -636,9 +616,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6855705.13,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B023_99999",
     "commune_deleguee_insee": "00000",
@@ -659,9 +637,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854169.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_zpe59o_99999",
     "commune_deleguee_insee": "00000",
@@ -682,9 +658,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6854091.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B015_99999",
     "commune_deleguee_insee": "00000",
@@ -705,9 +679,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852964.76,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B010_99999",
     "commune_deleguee_insee": "00000",
@@ -728,9 +700,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852856.45,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_vwgc9s_99999",
     "commune_deleguee_insee": "00000",
@@ -751,9 +721,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6853815.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B040_99999",
     "commune_deleguee_insee": "00000",
@@ -774,9 +742,7 @@ exports[`balJSONlegacy2balJSON > should convert BAL JSON legacy into BAL JSON wi
     "y": 6852845.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_k6znad_99999",
     "commune_deleguee_insee": "00000",
@@ -871,9 +837,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6853881.3,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00029",
     "commune_deleguee_insee": "00000",
@@ -894,9 +858,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854310.41,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00031",
     "commune_deleguee_insee": "00000",
@@ -917,9 +879,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854342.28,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00033",
     "commune_deleguee_insee": "00000",
@@ -1262,9 +1222,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852855.2,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -1285,9 +1243,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854307.15,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -1308,9 +1264,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854280.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00002",
     "commune_deleguee_insee": "00000",
@@ -1331,9 +1285,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854326.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_ty2whe_99999",
     "commune_deleguee_insee": "00000",
@@ -1354,9 +1306,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852668.52,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B019_99999",
     "commune_deleguee_insee": "00000",
@@ -1377,9 +1327,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852865.29,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_adckqc_99999",
     "commune_deleguee_insee": "00000",
@@ -1400,9 +1348,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6851883.59,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_t6v2h3_99999",
     "commune_deleguee_insee": "00000",
@@ -1423,9 +1369,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6855705.13,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B023_99999",
     "commune_deleguee_insee": "00000",
@@ -1446,9 +1390,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854169.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_zpe59o_99999",
     "commune_deleguee_insee": "00000",
@@ -1469,9 +1411,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6854091.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B015_99999",
     "commune_deleguee_insee": "00000",
@@ -1492,9 +1432,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852964.76,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B010_99999",
     "commune_deleguee_insee": "00000",
@@ -1515,9 +1453,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852856.45,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_vwgc9s_99999",
     "commune_deleguee_insee": "00000",
@@ -1538,9 +1474,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6853815.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B040_99999",
     "commune_deleguee_insee": "00000",
@@ -1561,9 +1495,7 @@ exports[`balJSONlegacy2balJSON > should convert partial BAL JSON legacy into BAL
     "y": 6852845.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_k6znad_99999",
     "commune_deleguee_insee": "00000",

--- a/src/bal-converter/helpers/__snapshots__/bal-position-type-to-ban-position-type.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-position-type-to-ban-position-type.test.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`balPositionTypeToBanPositionType > should return building 1`] = `"building"`;
+
+exports[`balPositionTypeToBanPositionType > should return entrance 1`] = `"entrance"`;
+
+exports[`balPositionTypeToBanPositionType > should return other 1`] = `"other"`;
+
+exports[`balPositionTypeToBanPositionType > should return parcel 1`] = `"parcel"`;
+
+exports[`balPositionTypeToBanPositionType > should return postal delivery 1`] = `"postal delivery"`;
+
+exports[`balPositionTypeToBanPositionType > should return segment 1`] = `"segment"`;
+
+exports[`balPositionTypeToBanPositionType > should return staircase identifier 1`] = `"staircase identifier"`;
+
+exports[`balPositionTypeToBanPositionType > should return undefined 1`] = `undefined`;
+
+exports[`balPositionTypeToBanPositionType > should return undefined 2`] = `undefined`;
+
+exports[`balPositionTypeToBanPositionType > should return utility service 1`] = `"utility service"`;

--- a/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
@@ -5,13 +5,17 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
   "addresses": {
     "03fb190a-cf5b-4f48-a1ab-7caa4d10e157": {
       "certified": false,
-      "commonToponymID": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "03fb190a-cf5b-4f48-a1ab-7caa4d10e157",
+      "mainCommonToponymID": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000C0115,212860000C0114",
+          ],
+        },
+      },
       "number": 1,
-      "parcels": [
-        "212860000C0115,212860000C0114",
-      ],
       "positions": [
         {
           "geometry": {
@@ -21,7 +25,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
         {
           "geometry": {
@@ -31,21 +35,20 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "logement",
+          "type": "unit identifier",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2022-08-23T00:00:00.000Z",
     },
     "18510122-0ad8-49fe-bbae-ca484d8f4e01": {
       "certified": false,
-      "commonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "18510122-0ad8-49fe-bbae-ca484d8f4e01",
+      "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
+      "meta": {},
       "number": 31,
-      "parcels": [
-        "",
-      ],
       "positions": [
         {
           "geometry": {
@@ -55,21 +58,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "1890569a-d05f-4cf9-b27b-9172c497023e": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "1890569a-d05f-4cf9-b27b-9172c497023e",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0237",
+          ],
+        },
+      },
       "number": 6,
-      "parcels": [
-        "212860000D0237",
-      ],
       "positions": [
         {
           "geometry": {
@@ -79,21 +87,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "2480fe76-bbd8-4703-a41a-5c43fd3c5891": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "2480fe76-bbd8-4703-a41a-5c43fd3c5891",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0053,212860000D0054",
+          ],
+        },
+      },
       "number": 10,
-      "parcels": [
-        "212860000D0053,212860000D0054",
-      ],
       "positions": [
         {
           "geometry": {
@@ -103,21 +116,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "28fd0d23-9f3a-4ac0-8e17-05f851546f34": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "28fd0d23-9f3a-4ac0-8e17-05f851546f34",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0305,212860000D0307,212860000D0308,212860000D0266",
+          ],
+        },
+      },
       "number": 5,
-      "parcels": [
-        "212860000D0305,212860000D0307,212860000D0308,212860000D0266",
-      ],
       "positions": [
         {
           "geometry": {
@@ -127,21 +145,20 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "29387aa3-1dc6-4e38-a1e9-aea350c91296": {
       "certified": false,
-      "commonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "29387aa3-1dc6-4e38-a1e9-aea350c91296",
+      "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
+      "meta": {},
       "number": 33,
-      "parcels": [
-        "",
-      ],
       "positions": [
         {
           "geometry": {
@@ -151,21 +168,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "48691fd6-a611-4335-b346-a05679bcb31d": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "48691fd6-a611-4335-b346-a05679bcb31d",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0143",
+          ],
+        },
+      },
       "number": 11,
-      "parcels": [
-        "212860000D0143",
-      ],
       "positions": [
         {
           "geometry": {
@@ -175,21 +197,20 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "4afc82e4-694e-4bb3-81cb-0a32cd59a300": {
       "certified": false,
-      "commonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "4afc82e4-694e-4bb3-81cb-0a32cd59a300",
+      "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
+      "meta": {},
       "number": 29,
-      "parcels": [
-        "",
-      ],
       "positions": [
         {
           "geometry": {
@@ -199,21 +220,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "5114f638-f99d-4da2-b3ed-d2e2c3a32765": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "5114f638-f99d-4da2-b3ed-d2e2c3a32765",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0290,212860000D0292,212860000D0273,212860000D0288",
+          ],
+        },
+      },
       "number": 9,
-      "parcels": [
-        "212860000D0290,212860000D0292,212860000D0273,212860000D0288",
-      ],
       "positions": [
         {
           "geometry": {
@@ -223,21 +249,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "5139b74a-f569-4008-aade-3bb955186134": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "5139b74a-f569-4008-aade-3bb955186134",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "21286000ZC0087",
+          ],
+        },
+      },
       "number": 8,
-      "parcels": [
-        "21286000ZC0087",
-      ],
       "positions": [
         {
           "geometry": {
@@ -247,21 +278,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "577e9019-42bb-4965-b287-fe4cebe41038": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "577e9019-42bb-4965-b287-fe4cebe41038",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0113",
+          ],
+        },
+      },
       "number": 1,
-      "parcels": [
-        "212860000D0113",
-      ],
       "positions": [
         {
           "geometry": {
@@ -271,21 +307,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "61b54625-bef6-4450-95e1-b6f37d93441a": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "61b54625-bef6-4450-95e1-b6f37d93441a",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0113",
+          ],
+        },
+      },
       "number": 3,
-      "parcels": [
-        "212860000D0113",
-      ],
       "positions": [
         {
           "geometry": {
@@ -295,21 +336,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "6edd2c77-e8db-4384-bbb6-810e868d4dee": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "6edd2c77-e8db-4384-bbb6-810e868d4dee",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0304,212860000D0229",
+          ],
+        },
+      },
       "number": 3,
-      "parcels": [
-        "212860000D0304,212860000D0229",
-      ],
       "positions": [
         {
           "geometry": {
@@ -319,21 +365,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "7a9e11ff-31b6-4f14-8494-55369e7dce04": {
       "certified": false,
-      "commonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "7a9e11ff-31b6-4f14-8494-55369e7dce04",
+      "mainCommonToponymID": "468d0b9b-ec0c-448d-8188-4e28762251e2",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0293",
+          ],
+        },
+      },
       "number": 7,
-      "parcels": [
-        "212860000D0293",
-      ],
       "positions": [
         {
           "geometry": {
@@ -343,21 +394,20 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "8c12024d-6216-4634-aca0-598f569d632b": {
       "certified": false,
-      "commonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "8c12024d-6216-4634-aca0-598f569d632b",
+      "mainCommonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
+      "meta": {},
       "number": 2,
-      "parcels": [
-        "",
-      ],
       "positions": [
         {
           "geometry": {
@@ -367,21 +417,20 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "aeda3e20-8204-4d2b-8e59-184df887ae4e": {
       "certified": false,
-      "commonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "aeda3e20-8204-4d2b-8e59-184df887ae4e",
+      "mainCommonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
+      "meta": {},
       "number": 1,
-      "parcels": [
-        "",
-      ],
       "positions": [
         {
           "geometry": {
@@ -391,7 +440,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
         {
           "geometry": {
@@ -401,21 +450,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "logement",
+          "type": "unit identifier",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2022-08-23T00:00:00.000Z",
     },
     "d19b14c9-d9d0-478f-b741-c973d05c343f": {
       "certified": false,
-      "commonToponymID": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "d19b14c9-d9d0-478f-b741-c973d05c343f",
+      "mainCommonToponymID": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000C0237,212860000C0107",
+          ],
+        },
+      },
       "number": 2,
-      "parcels": [
-        "212860000C0237,212860000C0107",
-      ],
       "positions": [
         {
           "geometry": {
@@ -425,21 +479,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "e6278261-1a1b-4606-9c20-a8f2d06738fa": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "e6278261-1a1b-4606-9c20-a8f2d06738fa",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0236",
+          ],
+        },
+      },
       "number": 8,
-      "parcels": [
-        "212860000D0236",
-      ],
       "positions": [
         {
           "geometry": {
@@ -449,21 +508,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "e9de2ecf-e082-448b-9a21-fe9d38d017ae": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "e9de2ecf-e082-448b-9a21-fe9d38d017ae",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0150",
+          ],
+        },
+      },
       "number": 7,
-      "parcels": [
-        "212860000D0150",
-      ],
       "positions": [
         {
           "geometry": {
@@ -473,21 +537,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "f1a28bf1-fac3-41f0-8cb4-3abc82b2b963": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "f1a28bf1-fac3-41f0-8cb4-3abc82b2b963",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0230",
+          ],
+        },
+      },
       "number": 5,
-      "parcels": [
-        "212860000D0230",
-      ],
       "positions": [
         {
           "geometry": {
@@ -497,21 +566,26 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "ff8bb658-3f73-4ac3-ab04-7966e869e991": {
       "certified": false,
-      "commonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "ff8bb658-3f73-4ac3-ab04-7966e869e991",
+      "mainCommonToponymID": "c9b6df77-638b-4b30-991e-71486a91ea95",
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0148,212860000D0284",
+          ],
+        },
+      },
       "number": 9,
-      "parcels": [
-        "212860000D0148,212860000D0284",
-      ],
       "positions": [
         {
           "geometry": {
@@ -521,9 +595,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
             ],
             "type": "Point",
           },
-          "type": "entrée",
+          "type": "entrance",
         },
       ],
+      "secondaryCommonToponymIDs": undefined,
       "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
@@ -539,15 +614,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "16e337a0-d0c7-4c24-b8dc-e43edbd4d273",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Les Bois Perdus",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -563,15 +636,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "1748660f-d473-400a-88ad-52d55f3fc9f5",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Observatoire d’Hyrule",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -587,15 +658,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "17ec2d21-8c66-4a43-921e-817fb489f899",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Les Quatre Maisons",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -611,15 +680,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "26d79f86-7051-4c51-a1b1-966fd7f1e345",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Armurerie de l’Ancien Royaume",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -635,15 +702,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "3c091079-e2c0-4151-8d1f-3a000bc29894",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Empreinte du Fleau",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -659,15 +724,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "413eb0cb-561a-435a-af8f-d244023f9b40",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "La voie celeste",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -683,15 +746,19 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "468d0b9b-ec0c-448d-8188-4e28762251e2",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Route de la Baleine",
         },
       ],
-      "parcels": [
-        "212860000D0053,212860000D0054",
-      ],
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0053,212860000D0054",
+          ],
+        },
+      },
       "type": {
         "value": "voie",
       },
@@ -707,15 +774,19 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Rue Rhoam Bosphoramus",
         },
       ],
-      "parcels": [
-        "212860000C0237,212860000C0107",
-      ],
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000C0237,212860000C0107",
+          ],
+        },
+      },
       "type": {
         "value": "voie",
       },
@@ -731,15 +802,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "7ce61747-d840-4019-97be-82dc0568619f",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Allée des Prodiges",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -755,15 +824,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "8b3ae0a2-81ad-45b6-b58a-925868e6a3bc",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Passage de Daruk",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -779,15 +846,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Impasse des lynels",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -803,15 +868,19 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "c9b6df77-638b-4b30-991e-71486a91ea95",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Chemin de la legende",
         },
       ],
-      "parcels": [
-        "212860000D0143",
-      ],
+      "meta": {
+        "cadastre": {
+          "ids": [
+            "212860000D0143",
+          ],
+        },
+      },
       "type": {
         "value": "voie",
       },
@@ -827,15 +896,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "cfdb5a41-75b4-4964-ad95-f14f4ab6b23f",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Etang du sorcier",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -851,15 +918,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "d447b2d5-ff6d-42bc-8cb2-7efbfa2030e7",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Arbre Mojo",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -875,15 +940,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "e89808c4-7f7e-46f3-b3a8-d40e4b783d8d",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Chemin du Moulin",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -899,15 +962,13 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         "type": "Point",
       },
       "id": "f52cf4c8-df1d-4619-9a64-0b0b3ee01c4e",
-      "label": [
+      "labels": [
         {
           "isoCode": "fra",
           "value": "Relai d’Hylia",
         },
       ],
-      "parcels": [
-        "",
-      ],
+      "meta": {},
       "type": {
         "value": "voie",
       },

--- a/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
@@ -11,17 +11,17 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
     "type": "Point",
   },
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
@@ -36,23 +36,23 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
     "type": "Point",
   },
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
-exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and other toponyms 1`] = `
+exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistrictID 1`] = `
 {
-  "districtID": undefined,
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "geometry": {
     "coordinates": [
       1,
@@ -61,17 +61,17 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and other to
     "type": "Point",
   },
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
@@ -86,7 +86,7 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
     "type": "Point",
   },
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
@@ -96,17 +96,17 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
       "value": "Baleen ibilbidea",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
 exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = `
 {
-  "districtID": undefined,
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "geometry": {
     "coordinates": [
       1,
@@ -115,17 +115,17 @@ exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = 
     "type": "Point",
   },
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Avenue Rhoam Bosphoramus",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
@@ -140,17 +140,17 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
     "type": "Point",
   },
   "id": undefined,
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
 
@@ -165,16 +165,16 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 2`] = `
     "type": "Point",
   },
   "id": undefined,
-  "label": [
+  "labels": [
     {
       "isoCode": "fra",
       "value": "Route de la Baleine",
     },
   ],
-  "parcels": undefined,
+  "meta": {},
   "type": {
     "value": "voie",
   },
-  "updateDate": "2021-01-01",
+  "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;

--- a/src/bal-converter/helpers/__snapshots__/csv-bal-to-json-bal.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/csv-bal-to-json-bal.test.ts.snap
@@ -75,9 +75,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6853881.3,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00029",
     "commune_deleguee_insee": "00000",
@@ -98,9 +96,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854310.41,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00031",
     "commune_deleguee_insee": "00000",
@@ -121,9 +117,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854342.28,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_mz58hg_00033",
     "commune_deleguee_insee": "00000",
@@ -475,9 +469,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852855.2,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -498,9 +490,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854307.15,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00001",
     "commune_deleguee_insee": "00000",
@@ -521,9 +511,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854280.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_0085_00002",
     "commune_deleguee_insee": "00000",
@@ -544,9 +532,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854326.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_ty2whe_99999",
     "commune_deleguee_insee": "00000",
@@ -567,9 +553,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852668.52,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B019_99999",
     "commune_deleguee_insee": "00000",
@@ -590,9 +574,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852865.29,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_adckqc_99999",
     "commune_deleguee_insee": "00000",
@@ -613,9 +595,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6851883.59,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_t6v2h3_99999",
     "commune_deleguee_insee": "00000",
@@ -636,9 +616,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6855705.13,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B023_99999",
     "commune_deleguee_insee": "00000",
@@ -659,9 +637,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854169.7,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_zpe59o_99999",
     "commune_deleguee_insee": "00000",
@@ -682,9 +658,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6854091.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B015_99999",
     "commune_deleguee_insee": "00000",
@@ -705,9 +679,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852964.76,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B010_99999",
     "commune_deleguee_insee": "00000",
@@ -728,9 +700,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852856.45,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_vwgc9s_99999",
     "commune_deleguee_insee": "00000",
@@ -751,9 +721,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6853815.12,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_B040_99999",
     "commune_deleguee_insee": "00000",
@@ -774,9 +742,7 @@ exports[`csvBalToJsonBal > should convert BAL CSV list into BAL JSON list 1`] = 
     "y": 6852845.39,
   },
   {
-    "cad_parcelles": [
-      "",
-    ],
+    "cad_parcelles": [],
     "certification_commune": false,
     "cle_interop": "21286_k6znad_99999",
     "commune_deleguee_insee": "00000",

--- a/src/bal-converter/helpers/__snapshots__/digest-ids-from-bal-uids.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/digest-ids-from-bal-uids.test.ts.snap
@@ -4,14 +4,14 @@ exports[`digestIDsFromBalUIDs > should return an empty object for an empty BanID
 
 exports[`digestIDsFromBalUIDs > should return an empty object for an undefined BanIDs 1`] = `{}`;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with addrID and mainTopoID 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with addrID and mainTopoID 1`] = `
 {
   "addressID": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainTopoID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
 }
 `;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with addrID and secondaryTopoIDs 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with addrID and secondaryTopoIDs 1`] = `
 {
   "addressID": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "secondaryTopoIDs": [
@@ -22,9 +22,10 @@ exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs
 }
 `;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with addrID, mainTopoID and secondaryTopoIDs 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with addrID, mainTopoID, secondaryTopoIDs and districtID 1`] = `
 {
   "addressID": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "mainTopoID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "secondaryTopoIDs": [
     "cccccccc-0000-4aaa-9000-1234567890cc",
@@ -34,19 +35,32 @@ exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs
 }
 `;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with only addrID 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with mainTopoID and districtID 1`] = `
+{
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
+  "mainTopoID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+}
+`;
+
+exports[`digestIDsFromBalUIDs > should return an object with BanID with only addrID 1`] = `
 {
   "addressID": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
 }
 `;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with only mainTopoID 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with only districtID 1`] = `
+{
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
+}
+`;
+
+exports[`digestIDsFromBalUIDs > should return an object with BanID with only mainTopoID 1`] = `
 {
   "mainTopoID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
 }
 `;
 
-exports[`digestIDsFromBalUIDs > should return an object with BanID for an BanIDs with only secondaryTopoIDs 1`] = `
+exports[`digestIDsFromBalUIDs > should return an object with BanID with only secondaryTopoIDs 1`] = `
 {
   "secondaryTopoIDs": [
     "cccccccc-0000-4aaa-9000-1234567890cc",

--- a/src/bal-converter/helpers/bal-addr-to-ban-addr.test.ts
+++ b/src/bal-converter/helpers/bal-addr-to-ban-addr.test.ts
@@ -3,18 +3,14 @@ import type { BanAddress } from "../../types/ban-types.js";
 
 import { describe, expect, test } from "vitest";
 import {
-  idsIdentifierIndex,
   numberForTopo as IS_TOPO_NB,
 } from "../bal-converter.config.js";
-import { addrID, mainTopoID, secondaryTopoIDs } from "./__mocks__/fake-data.js";
+import { idSampleWithAddressId, 
+  idSampleWithMainTopoId,
+  idSampleWithAddressIdAndMainTopoId,
+  idSampleWithAllIds
+} from "./__mocks__/fake-data.js";
 import balAddrToBanAddr from "./bal-addr-to-ban-addr";
-
-const idSampleWithBanId = `${idsIdentifierIndex.addressID}${addrID}`;
-const idSampleWithMainTopoId = `${idsIdentifierIndex.mainTopoID}${mainTopoID}`;
-const idSampleWithBanIdAndMainTopoId = `${idsIdentifierIndex.addressID}${addrID} ${idsIdentifierIndex.mainTopoID}${mainTopoID}`;
-const idSampleWithAllIds = `${idsIdentifierIndex.addressID}${addrID} ${
-  idsIdentifierIndex.mainTopoID
-}${mainTopoID} !${secondaryTopoIDs.join("|")}`;
 
 const defaultTestBalAddress: BalAdresse = {
   cle_interop: "21286_0001_00001",
@@ -27,7 +23,7 @@ const defaultTestBalAddress: BalAdresse = {
   y: 2,
   long: 1,
   lat: 2,
-  date_der_maj: "2021-01-01",
+  date_der_maj: new Date ("2021-01-01"),
   certification_commune: true,
   source: "BAL",
 };
@@ -40,7 +36,7 @@ describe("balAddrToBanAddr", () => {
   test("should return BanAddress with BanID without BanTopoID", async () => {
     const testBalAddress: BalAdresse = {
       ...defaultTestBalAddress,
-      uid_adresse: idSampleWithBanId,
+      uid_adresse: idSampleWithAddressId,
     };
 
     expect(balAddrToBanAddr(testBalAddress)).toMatchSnapshot();
@@ -58,13 +54,13 @@ describe("balAddrToBanAddr", () => {
   test("should return BanAddress with BanID and BanTopoID", async () => {
     const testBalAddress: BalAdresse = {
       ...defaultTestBalAddress,
-      uid_adresse: idSampleWithBanIdAndMainTopoId,
+      uid_adresse: idSampleWithAddressIdAndMainTopoId,
     };
 
     expect(balAddrToBanAddr(testBalAddress)).toMatchSnapshot();
   });
 
-  test("should return BanAddress with BanID, BanTopoID and other toponyms", async () => {
+  test("should return BanAddress with BanID, BanTopoID, other toponyms and BanDistrictID", async () => {
     const testBalAddress: BalAdresse = {
       ...defaultTestBalAddress,
       uid_adresse: idSampleWithAllIds,

--- a/src/bal-converter/helpers/bal-position-type-to-ban-position-type.test.ts
+++ b/src/bal-converter/helpers/bal-position-type-to-ban-position-type.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { convertBalPositionTypeToBanPositionType } from './bal-position-type-to-ban-position-type' 
+
+describe("balPositionTypeToBanPositionType", () => {
+
+  test("should return undefined", async () => {
+    expect(convertBalPositionTypeToBanPositionType('')).toMatchSnapshot();
+  });
+
+  test("should return undefined", async () => {
+    expect(convertBalPositionTypeToBanPositionType('not-in-dictionary')).toMatchSnapshot();
+  });
+
+  test("should return entrance", async () => {
+    expect(convertBalPositionTypeToBanPositionType('entrée')).toMatchSnapshot();
+  });
+
+  test("should return building", async () => {
+    expect(convertBalPositionTypeToBanPositionType('bâtiment')).toMatchSnapshot();
+  });
+
+  test("should return staircase identifier", async () => {
+    expect(convertBalPositionTypeToBanPositionType('cage d’escalier')).toMatchSnapshot();
+  });
+
+  test("should return utility service", async () => {
+    expect(convertBalPositionTypeToBanPositionType('service technique')).toMatchSnapshot();
+  });
+
+  test("should return postal delivery", async () => {
+    expect(convertBalPositionTypeToBanPositionType('délivrance postale')).toMatchSnapshot();
+  });
+
+  test("should return parcel", async () => {
+    expect(convertBalPositionTypeToBanPositionType('parcelle')).toMatchSnapshot();
+  });
+
+  test("should return segment", async () => {
+    expect(convertBalPositionTypeToBanPositionType('segment')).toMatchSnapshot();
+  });
+
+  test("should return other", async () => {
+    expect(convertBalPositionTypeToBanPositionType('autre')).toMatchSnapshot();
+  });
+})

--- a/src/bal-converter/helpers/bal-position-type-to-ban-position-type.ts
+++ b/src/bal-converter/helpers/bal-position-type-to-ban-position-type.ts
@@ -1,0 +1,14 @@
+import positionTypeDictionary from './position-type-dictionary.json' assert { type: 'json' }
+
+const positionTypeConverter = (data: any, langFrom: string, langTo: string) => {
+  const dataMemorized = data.reduce((acc: any, val: any) => {
+      return {
+          ...acc,
+          [val[langFrom]]: val[langTo],
+      }
+  }, {})
+
+  return (key: string) => dataMemorized[key]
+} 
+
+export const convertBalPositionTypeToBanPositionType = positionTypeConverter(positionTypeDictionary, 'fra', 'eng')

--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.test.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.test.ts
@@ -2,16 +2,13 @@ import type { BalAdresse } from "../../types/bal-types.js";
 import type { BanCommonToponym } from "../../types/ban-types.js";
 
 import { describe, expect, test } from "vitest";
-import { idsIdentifierIndex } from "../bal-converter.config.js";
-import { addrID, mainTopoID, secondaryTopoIDs } from "./__mocks__/fake-data.js";
+import { idSampleWithAddressId, 
+  idSampleWithMainTopoId, 
+  idSampleWithAddressIdAndMainTopoId,
+  idSampleWithAllIds
+} from "./__mocks__/fake-data.js";
 import balTopoToBanTopo from "./bal-topo-to-ban-topo";
 
-const idSampleWithBanId = `${idsIdentifierIndex.addressID}${addrID}`;
-const idSampleWithMainTopoId = `${idsIdentifierIndex.mainTopoID}${mainTopoID}`;
-const idSampleWithBanIdAndMainTopoId = `${idsIdentifierIndex.addressID}${addrID} ${idsIdentifierIndex.mainTopoID}${mainTopoID}`;
-const idSampleWithAllIds = `${idsIdentifierIndex.addressID}${addrID} ${
-  idsIdentifierIndex.mainTopoID
-}${mainTopoID} !${secondaryTopoIDs.join("|")}`;
 
 const defaultTestBalAdresse: BalAdresse = {
   cle_interop: "21286_0001_00001",
@@ -24,7 +21,7 @@ const defaultTestBalAdresse: BalAdresse = {
   y: 2,
   long: 1,
   lat: 2,
-  date_der_maj: "2021-01-01",
+  date_der_maj: new Date("2021-01-01"),
   certification_commune: true,
   source: "BAL",
 };
@@ -38,7 +35,7 @@ describe("balTopoToBanTopo", () => {
     // TODO: In next version - should probably return BanToponym without temporary BanTopoID ?
     const testBalAdresse: BalAdresse = {
       ...defaultTestBalAdresse,
-      uid_adresse: idSampleWithBanId,
+      uid_adresse: idSampleWithAddressId,
     };
     expect(balTopoToBanTopo(testBalAdresse)).toMatchSnapshot();
   });
@@ -54,12 +51,12 @@ describe("balTopoToBanTopo", () => {
   test("should return BanToponym with BanTopoID (2)", async () => {
     const testBalAdresse: BalAdresse = {
       ...defaultTestBalAdresse,
-      uid_adresse: idSampleWithBanIdAndMainTopoId,
+      uid_adresse: idSampleWithAddressIdAndMainTopoId,
     };
     expect(balTopoToBanTopo(testBalAdresse)).toMatchSnapshot();
   });
 
-  test("should return BanToponym with BanTopoID and other toponyms", async () => {
+  test("should return BanToponym with BanTopoID and BanDistrictID", async () => {
     const testBalAdresse: BalAdresse = {
       ...defaultTestBalAdresse,
       uid_adresse: idSampleWithAllIds,

--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
@@ -22,22 +22,24 @@ const balTopoToBanTopo = (
       ).map((key) => [isoCodeFromBalNomVoie(key), balAdresse[key]])
     ),
   };
-
+  const meta = balAdresse.cad_parcelles && balAdresse.cad_parcelles.length > 0 
+    ? {cadastre: {ids: balAdresse.cad_parcelles}} 
+    : {}
   return {
     ...(oldBanCommonToponym || {}),
     id: mainTopoID,
     districtID,
-    label: Object.entries(labels).map(([isoCode, value]) => ({
+    labels: Object.entries(labels).map(([isoCode, value]) => ({
       isoCode,
       value,
-    })), // TODO: rename key 'label' to 'labels'
+    })),
     type: { value: "voie" }, // TODO: How to get the type from the BAL?
     geometry: {
       type: "Point",
       coordinates: [balAdresse.long, balAdresse.lat],
     },
-    parcels: balAdresse.cad_parcelles,
     updateDate: balAdresse.date_der_maj,
+    meta,
   };
 };
 

--- a/src/bal-converter/helpers/csv-bal-to-json-bal.ts
+++ b/src/bal-converter/helpers/csv-bal-to-json-bal.ts
@@ -22,7 +22,7 @@ const csvBalToJsonBal = (csv: string): Bal => {
         case "certification_commune":
           return value === "1";
         case "cad_parcelles":
-          return value.split(",");
+          return value !== '' ? value.split(",") : []
         case "date_der_maj":
           return new Date(value);
         default:

--- a/src/bal-converter/helpers/digest-ids-from-bal-uids.test.ts
+++ b/src/bal-converter/helpers/digest-ids-from-bal-uids.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "vitest";
 import {
-  idSampleWithBanId,
+  idSampleWithAddressId,
   idSampleWithMainTopoId,
   idSampleWithSecondaryTopoId,
-  idSampleWithBanIdAndMainTopoId,
-  idSampleWithBanIdAndSecondaryTopoId,
+  idSampleWithDistrictId,
+  idSampleWithAddressIdAndMainTopoId,
+  idSampleWithAddressIdAndSecondaryTopoId,
+  idSampleWithMainTopoIdAndDistrictId,
   idSampleWithAllIds,
 } from "./__mocks__/fake-data.js";
 import digestIDsFromBalUIDs from "./digest-ids-from-bal-uids.js";
@@ -18,27 +20,35 @@ describe("digestIDsFromBalUIDs", () => {
     const id = digestIDsFromBalUIDs("");
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with only addrID", async () => {
-    const id = digestIDsFromBalUIDs(idSampleWithBanId);
+  test("should return an object with BanID with only addrID", async () => {
+    const id = digestIDsFromBalUIDs(idSampleWithAddressId);
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with only mainTopoID", async () => {
+  test("should return an object with BanID with only mainTopoID", async () => {
     const id = digestIDsFromBalUIDs(idSampleWithMainTopoId);
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with only secondaryTopoIDs", async () => {
+  test("should return an object with BanID with only secondaryTopoIDs", async () => {
     const id = digestIDsFromBalUIDs(idSampleWithSecondaryTopoId);
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with addrID and mainTopoID", async () => {
-    const id = digestIDsFromBalUIDs(idSampleWithBanIdAndMainTopoId);
+  test("should return an object with BanID with only districtID", async () => {
+    const id = digestIDsFromBalUIDs(idSampleWithDistrictId);
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with addrID and secondaryTopoIDs", async () => {
-    const id = digestIDsFromBalUIDs(idSampleWithBanIdAndSecondaryTopoId);
+  test("should return an object with BanID with addrID and mainTopoID", async () => {
+    const id = digestIDsFromBalUIDs(idSampleWithAddressIdAndMainTopoId);
     expect(id).toMatchSnapshot();
   });
-  test("should return an object with BanID for an BanIDs with addrID, mainTopoID and secondaryTopoIDs", async () => {
+  test("should return an object with BanID with addrID and secondaryTopoIDs", async () => {
+    const id = digestIDsFromBalUIDs(idSampleWithAddressIdAndSecondaryTopoId);
+    expect(id).toMatchSnapshot();
+  });
+  test("should return an object with BanID with mainTopoID and districtID", async () => {
+    const id = digestIDsFromBalUIDs(idSampleWithMainTopoIdAndDistrictId);
+    expect(id).toMatchSnapshot();
+  });
+  test("should return an object with BanID with addrID, mainTopoID, secondaryTopoIDs and districtID", async () => {
     const id = digestIDsFromBalUIDs(idSampleWithAllIds);
     expect(id).toMatchSnapshot();
   });

--- a/src/bal-converter/helpers/position-type-dictionary.json
+++ b/src/bal-converter/helpers/position-type-dictionary.json
@@ -1,0 +1,11 @@
+[
+  {"fra": "entrée", "eng": "entrance"},
+  {"fra": "bâtiment", "eng": "building"},
+  {"fra": "cage d’escalier", "eng": "staircase identifier"},
+  {"fra": "logement", "eng": "unit identifier"},
+  {"fra": "service technique", "eng": "utility service"},
+  {"fra": "délivrance postale", "eng": "postal delivery"},
+  {"fra": "parcelle", "eng": "parcel"},
+  {"fra": "segment", "eng": "segment"},
+  {"fra": "autre", "eng": "other"}
+]

--- a/src/types/ban-types.d.ts
+++ b/src/types/ban-types.d.ts
@@ -20,7 +20,7 @@ export type Position = {
 
 export type BanDistrict = {
   districtID: DistrictInseeID; // code INSEE de la commune
-  label: {
+  labels: {
     isoCode: LangISO639v3; // code ISO de la langue
     value: string; // nom de la voie
   }[];
@@ -29,10 +29,16 @@ export type BanDistrict = {
 
 export type BanDistricts = BanDistrict[];
 
+export type Meta = {
+  cadastre?:{
+    ids: string[];
+  }
+}
+
 export type BanCommonToponym = {
   id?: BanCommonTopoID; // identifiant unique de la voie
   districtID: DistrictInseeID; // code INSEE de la commune
-  label: {
+  labels: {
     isoCode: LangISO639v3; // code ISO de la langue
     value: string; // nom de la voie
   }[];
@@ -43,8 +49,8 @@ export type BanCommonToponym = {
     type: "Point";
     coordinates: [number, number, number?];
   };
-  parcels?: string[]; // parcelles cadastrales de la voie
   updateDate: DateISO8601; // date de mise à jour de la voie
+  meta: Meta
 };
 
 export type BanCommonToponyms = BanCommonToponym[];
@@ -52,13 +58,14 @@ export type BanCommonToponyms = BanCommonToponym[];
 export type BanAddress = {
   id?: BanID; // identifiant unique de l'adresse
   districtID: DistrictInseeID; // code INSEE de la commune
-  commonToponymID?: BanCommonTopoID; // identifiant unique de la voie
+  mainCommonToponymID: BanCommonTopoID; // identifiant unique du toponyme principal
+  secondaryCommonToponymIDs?: BanCommonTopoID[]; // identifiant unique des toponymes secondaires
   number: number; // numéro de l'adresse
   suffix?: string;
   positions: Position[]; // positions géographiques de l'adresse
-  parcels?: string[]; // parcelles cadastrales de l'adresse // TODO: Verrifier que les parcelles ne soit pas par position et non par adresse
   certified?: boolean;
   updateDate: DateISO8601; // date de mise à jour de l'adresse
+  meta: Meta
 };
 
 export type BanAddresses = BanAddress[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "es2022",
+    "module": "esnext",
     "lib": ["es2022", "dom"],
     "outDir": "dist",
     "moduleResolution": "node",


### PR DESCRIPTION
This PR aims to adapt the address and common toponym schemas to fit with the new standards : 

- switched "commonToponymID" key to "mainCommonToponymID"
- added "secondaryCommonToponymIDs
- switched "label" to "labels"
- transfered "parcels" into "meta" ( `meta : { cadastre : { ids: [...] } }` )
- added converter from bal position type (`fra`) to ban position type (`eng`)