### PR TITLE
fix docker compose env variable modification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./nodemon.json:/app/nodemon.json
     environment:
       - IDEFIX_ADMIN_TOKENS=${IDEFIX_ADMIN_TOKENS}
-      - IDEFIX_BANID_DISTRICTS=${IDEFIX_BANID_DISTRICTS}
+      - IDEFIX_BANID_DISTRICTS_COG=${IDEFIX_BANID_DISTRICTS_COG}
       - BAN_API_URL=${BAN_API_URL}
       - BAN_API_TOKEN=${BAN_API_TOKEN}
       - API_DEPOT_URL=${API_DEPOT_URL}


### PR DESCRIPTION
Fix in the docker compose file has the env variable for the list of authorized district has been modified from `IDEFIX_BANID_DISTRICTS` to `IDEFIX_BANID_DISTRICTS_COG`