### PR TITLE
Deleted useless variable in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./nodemon.json:/app/nodemon.json
     environment:
       - IDEFIX_ADMIN_TOKENS=${IDEFIX_ADMIN_TOKENS}
-      - IDEFIX_BANID_DISTRICTS=${IDEFIX_BANID_DISTRICTS}
       - BAN_API_URL=${BAN_API_URL}
       - BAN_API_TOKEN=${BAN_API_TOKEN}
       - API_DEPOT_URL=${API_DEPOT_URL}


### PR DESCRIPTION
Variable `IDEFIX_BANID_DISTRICTS` is not used anymore. As a consequence, we need to delete it from the docker compose file.