### PR TITLE
Fix get district from cog

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -20,7 +20,8 @@ router.get(
       let responseBody;
       const { cog } = req.params;
 
-      const district = await getDistrictFromCOG(cog);
+      const districtResponseRaw = await getDistrictFromCOG(cog);
+      const district = districtResponseRaw[0] // TODO : multiple district can have the same cog.
       const useBanId = district?.config?.useBanId;
       if (!useBanId) {
         const message = `District cog ${cog} do not support BanID`;


### PR DESCRIPTION
Fix : using the route /district/cog/:cog, response is an array of district as cog can be the same for multiples districts. As a correction, we now take the first district but we would need to handle this multiplicity in the future (or not use the cog anymore, but the district ID directly).