### PR TITLE
Modified get geometry for common toponyms

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
@@ -738,13 +738,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
     },
     "468d0b9b-ec0c-448d-8188-4e28762251e2": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {
-        "coordinates": [
-          1.082305,
-          48.762015,
-        ],
-        "type": "Point",
-      },
+      "geometry": {},
       "id": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "labels": [
         {
@@ -752,13 +746,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Route de la Baleine",
         },
       ],
-      "meta": {
-        "cadastre": {
-          "ids": [
-            "212860000D0053,212860000D0054",
-          ],
-        },
-      },
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -766,13 +754,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
     },
     "787ca7cf-8072-47ae-a8c6-98a62a8dd90c": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {
-        "coordinates": [
-          1.081444,
-          48.769615,
-        ],
-        "type": "Point",
-      },
+      "geometry": {},
       "id": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
       "labels": [
         {
@@ -780,13 +762,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Rue Rhoam Bosphoramus",
         },
       ],
-      "meta": {
-        "cadastre": {
-          "ids": [
-            "212860000C0237,212860000C0107",
-          ],
-        },
-      },
+      "meta": {},
       "type": {
         "value": "voie",
       },
@@ -794,13 +770,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
     },
     "7ce61747-d840-4019-97be-82dc0568619f": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {
-        "coordinates": [
-          1.085574,
-          48.774035,
-        ],
-        "type": "Point",
-      },
+      "geometry": {},
       "id": "7ce61747-d840-4019-97be-82dc0568619f",
       "labels": [
         {
@@ -838,13 +808,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
     },
     "c965715f-3874-4cba-ae4e-c9afa585f5eb": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {
-        "coordinates": [
-          1.079699,
-          48.773594,
-        ],
-        "type": "Point",
-      },
+      "geometry": {},
       "id": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
       "labels": [
         {
@@ -860,13 +824,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
     },
     "c9b6df77-638b-4b30-991e-71486a91ea95": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {
-        "coordinates": [
-          1.087958,
-          48.760488,
-        ],
-        "type": "Point",
-      },
+      "geometry": {},
       "id": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "labels": [
         {
@@ -874,13 +832,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Chemin de la legende",
         },
       ],
-      "meta": {
-        "cadastre": {
-          "ids": [
-            "212860000D0143",
-          ],
-        },
-      },
+      "meta": {},
       "type": {
         "value": "voie",
       },

--- a/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
@@ -3,13 +3,7 @@
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
 {
   "districtID": undefined,
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -28,13 +22,7 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
 {
   "districtID": undefined,
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -53,13 +41,7 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistrictID 1`] = `
 {
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -78,13 +60,7 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistr
 exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`] = `
 {
   "districtID": undefined,
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -107,13 +83,7 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
 exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = `
 {
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -132,13 +102,7 @@ exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = 
 exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
 {
   "districtID": undefined,
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": undefined,
   "labels": [
     {
@@ -157,13 +121,7 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 2`] = `
 {
   "districtID": undefined,
-  "geometry": {
-    "coordinates": [
-      1,
-      2,
-    ],
-    "type": "Point",
-  },
+  "geometry": {},
   "id": undefined,
   "labels": [
     {

--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
@@ -3,6 +3,7 @@ import type { BalAdresse, VoieNomIsoCodeKey } from "../../types/bal-types.js";
 import type { BanCommonToponym } from "../../types/ban-types.js";
 
 import digestIDsFromBalAddr from "./digest-ids-from-bal-addr.js";
+import { numberForTopo as IS_TOPO_NB } from "../bal-converter.config.js";
 
 const DEFAULT_ISO_LANG = "fra";
 
@@ -22,9 +23,18 @@ const balTopoToBanTopo = (
       ).map((key) => [isoCodeFromBalNomVoie(key), balAdresse[key]])
     ),
   };
-  const meta = balAdresse.cad_parcelles && balAdresse.cad_parcelles.length > 0 
+  const addrNumber = balAdresse.numero
+  const meta = addrNumber === Number(IS_TOPO_NB) && balAdresse.cad_parcelles && balAdresse.cad_parcelles.length > 0 
     ? {cadastre: {ids: balAdresse.cad_parcelles}} 
     : {}
+
+  const geometry = addrNumber === Number(IS_TOPO_NB) && balAdresse.long && balAdresse.lat 
+    ? {
+      type: "Point",
+      coordinates: [balAdresse.long, balAdresse.lat],
+    }
+    : {}
+
   return {
     ...(oldBanCommonToponym || {}),
     id: mainTopoID,
@@ -34,10 +44,7 @@ const balTopoToBanTopo = (
       value,
     })),
     type: { value: "voie" }, // TODO: How to get the type from the BAL?
-    geometry: {
-      type: "Point",
-      coordinates: [balAdresse.long, balAdresse.lat],
-    },
+    geometry,
     updateDate: balAdresse.date_der_maj,
     meta,
   };

--- a/src/types/ban-types.d.ts
+++ b/src/types/ban-types.d.ts
@@ -46,8 +46,8 @@ export type BanCommonToponym = {
     value: ToponymType; // type de la voie (voie, lieu-dit, etc.)
   };
   geometry: {
-    type: "Point";
-    coordinates: [number, number, number?];
+    type?: string;
+    coordinates?: number[];
   };
   updateDate: DateISO8601; // date de mise à jour de la voie
   meta: Meta


### PR DESCRIPTION
I. Context 

Currently, in id-fix, we are not making the distinction between a common toponym deducted from a BAL address line a common toponym explicitly described as a line (number 99999). As a consequence, id-fix were extracting the parcels and the geometry from the address line.

II. Enhancement

This PR aims to separate the processing between a deducted common toponym and an explicit common toponym. The parcels and the geometry data is ONLY taken from an explicit common toponym (number === 99999) and NOT for a deducted common toponym.