### PR TITLE
Modified data schema for optional fields

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
@@ -8,7 +8,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID and BanTopoID 1`
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -23,7 +22,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID and BanTopoID 1`
     },
   ],
   "secondaryCommonToponymIDs": undefined,
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -34,7 +32,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID without BanTopoI
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": undefined,
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -49,7 +46,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID without BanTopoI
     },
   ],
   "secondaryCommonToponymIDs": undefined,
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -60,7 +56,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID, othe
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -79,7 +74,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID, othe
     "cccccccc-1111-4aaa-9000-1234567890dd",
     "cccccccc-2222-4aaa-9000-1234567890ee",
   ],
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -90,7 +84,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanTopoID 1`] = `
   "districtID": undefined,
   "id": undefined,
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -105,7 +98,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanTopoID 1`] = `
     },
   ],
   "secondaryCommonToponymIDs": undefined,
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -116,7 +108,6 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -145,7 +136,6 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
     "cccccccc-1111-4aaa-9000-1234567890dd",
     "cccccccc-2222-4aaa-9000-1234567890ee",
   ],
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -156,7 +146,6 @@ exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1
   "districtID": undefined,
   "id": undefined,
   "mainCommonToponymID": undefined,
-  "meta": {},
   "number": 1,
   "positions": [
     {
@@ -171,7 +160,6 @@ exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1
     },
   ],
   "secondaryCommonToponymIDs": undefined,
-  "suffix": undefined,
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;

--- a/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
@@ -39,7 +39,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2022-08-23T00:00:00.000Z",
     },
     "18510122-0ad8-49fe-bbae-ca484d8f4e01": {
@@ -47,7 +46,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "18510122-0ad8-49fe-bbae-ca484d8f4e01",
       "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
-      "meta": {},
       "number": 31,
       "positions": [
         {
@@ -62,7 +60,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "1890569a-d05f-4cf9-b27b-9172c497023e": {
@@ -91,7 +88,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "2480fe76-bbd8-4703-a41a-5c43fd3c5891": {
@@ -120,7 +116,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "28fd0d23-9f3a-4ac0-8e17-05f851546f34": {
@@ -149,7 +144,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "29387aa3-1dc6-4e38-a1e9-aea350c91296": {
@@ -157,7 +151,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "29387aa3-1dc6-4e38-a1e9-aea350c91296",
       "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
-      "meta": {},
       "number": 33,
       "positions": [
         {
@@ -172,7 +165,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "48691fd6-a611-4335-b346-a05679bcb31d": {
@@ -201,7 +193,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "4afc82e4-694e-4bb3-81cb-0a32cd59a300": {
@@ -209,7 +200,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "4afc82e4-694e-4bb3-81cb-0a32cd59a300",
       "mainCommonToponymID": "7ce61747-d840-4019-97be-82dc0568619f",
-      "meta": {},
       "number": 29,
       "positions": [
         {
@@ -224,7 +214,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "5114f638-f99d-4da2-b3ed-d2e2c3a32765": {
@@ -253,7 +242,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "5139b74a-f569-4008-aade-3bb955186134": {
@@ -282,7 +270,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "577e9019-42bb-4965-b287-fe4cebe41038": {
@@ -311,7 +298,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "61b54625-bef6-4450-95e1-b6f37d93441a": {
@@ -340,7 +326,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "6edd2c77-e8db-4384-bbb6-810e868d4dee": {
@@ -369,7 +354,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "7a9e11ff-31b6-4f14-8494-55369e7dce04": {
@@ -398,7 +382,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "8c12024d-6216-4634-aca0-598f569d632b": {
@@ -406,7 +389,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "8c12024d-6216-4634-aca0-598f569d632b",
       "mainCommonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
-      "meta": {},
       "number": 2,
       "positions": [
         {
@@ -421,7 +403,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "aeda3e20-8204-4d2b-8e59-184df887ae4e": {
@@ -429,7 +410,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
       "id": "aeda3e20-8204-4d2b-8e59-184df887ae4e",
       "mainCommonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
-      "meta": {},
       "number": 1,
       "positions": [
         {
@@ -454,7 +434,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2022-08-23T00:00:00.000Z",
     },
     "d19b14c9-d9d0-478f-b741-c973d05c343f": {
@@ -483,7 +462,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "e6278261-1a1b-4606-9c20-a8f2d06738fa": {
@@ -512,7 +490,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "e9de2ecf-e082-448b-9a21-fe9d38d017ae": {
@@ -541,7 +518,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "f1a28bf1-fac3-41f0-8cb4-3abc82b2b963": {
@@ -570,7 +546,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "ff8bb658-3f73-4ac3-ab04-7966e869e991": {
@@ -599,7 +574,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
         },
       ],
       "secondaryCommonToponymIDs": undefined,
-      "suffix": "",
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
   },
@@ -620,7 +594,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Les Bois Perdus",
         },
       ],
-      "meta": {},
       "updateDate": "2022-06-03T00:00:00.000Z",
     },
     "1748660f-d473-400a-88ad-52d55f3fc9f5": {
@@ -639,7 +612,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Observatoire d’Hyrule",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
     "17ec2d21-8c66-4a43-921e-817fb489f899": {
@@ -658,7 +630,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Les Quatre Maisons",
         },
       ],
-      "meta": {},
       "updateDate": "2022-08-23T00:00:00.000Z",
     },
     "26d79f86-7051-4c51-a1b1-966fd7f1e345": {
@@ -677,7 +648,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Armurerie de l’Ancien Royaume",
         },
       ],
-      "meta": {},
       "updateDate": "2022-06-13T00:00:00.000Z",
     },
     "3c091079-e2c0-4151-8d1f-3a000bc29894": {
@@ -696,7 +666,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Empreinte du Fleau",
         },
       ],
-      "meta": {},
       "updateDate": "2020-08-31T00:00:00.000Z",
     },
     "413eb0cb-561a-435a-af8f-d244023f9b40": {
@@ -715,12 +684,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "La voie celeste",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
     "468d0b9b-ec0c-448d-8188-4e28762251e2": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {},
       "id": "468d0b9b-ec0c-448d-8188-4e28762251e2",
       "labels": [
         {
@@ -728,12 +695,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Route de la Baleine",
         },
       ],
-      "meta": {},
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "787ca7cf-8072-47ae-a8c6-98a62a8dd90c": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {},
       "id": "787ca7cf-8072-47ae-a8c6-98a62a8dd90c",
       "labels": [
         {
@@ -741,12 +706,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Rue Rhoam Bosphoramus",
         },
       ],
-      "meta": {},
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "7ce61747-d840-4019-97be-82dc0568619f": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {},
       "id": "7ce61747-d840-4019-97be-82dc0568619f",
       "labels": [
         {
@@ -754,7 +717,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Allée des Prodiges",
         },
       ],
-      "meta": {},
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "8b3ae0a2-81ad-45b6-b58a-925868e6a3bc": {
@@ -773,12 +735,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Passage de Daruk",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
     "c965715f-3874-4cba-ae4e-c9afa585f5eb": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {},
       "id": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
       "labels": [
         {
@@ -786,12 +746,10 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Impasse des lynels",
         },
       ],
-      "meta": {},
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "c9b6df77-638b-4b30-991e-71486a91ea95": {
       "districtID": "e2b5c142-3eb3-4d07-830a-3d1a59195dfd",
-      "geometry": {},
       "id": "c9b6df77-638b-4b30-991e-71486a91ea95",
       "labels": [
         {
@@ -799,7 +757,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Chemin de la legende",
         },
       ],
-      "meta": {},
       "updateDate": "2021-09-06T00:00:00.000Z",
     },
     "cfdb5a41-75b4-4964-ad95-f14f4ab6b23f": {
@@ -818,7 +775,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Etang du sorcier",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
     "d447b2d5-ff6d-42bc-8cb2-7efbfa2030e7": {
@@ -837,7 +793,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Arbre Mojo",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
     "e89808c4-7f7e-46f3-b3a8-d40e4b783d8d": {
@@ -856,7 +811,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Chemin du Moulin",
         },
       ],
-      "meta": {},
       "updateDate": "2023-01-13T00:00:00.000Z",
     },
     "f52cf4c8-df1d-4619-9a64-0b0b3ee01c4e": {
@@ -875,7 +829,6 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
           "value": "Relai d’Hylia",
         },
       ],
-      "meta": {},
       "updateDate": "2020-07-03T00:00:00.000Z",
     },
   },

--- a/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
 {
   "districtID": undefined,
-  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -11,7 +10,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -19,7 +17,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
 {
   "districtID": undefined,
-  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -27,7 +24,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -35,7 +31,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistrictID 1`] = `
 {
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
-  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -43,7 +38,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistr
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -51,7 +45,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistr
 exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`] = `
 {
   "districtID": undefined,
-  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -63,7 +56,6 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
       "value": "Baleen ibilbidea",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -71,7 +63,6 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
 exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = `
 {
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
-  "geometry": {},
   "id": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
   "labels": [
     {
@@ -79,7 +70,6 @@ exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = 
       "value": "Avenue Rhoam Bosphoramus",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -87,7 +77,6 @@ exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = 
 exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
 {
   "districtID": undefined,
-  "geometry": {},
   "id": undefined,
   "labels": [
     {
@@ -95,7 +84,6 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -103,7 +91,6 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
 exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 2`] = `
 {
   "districtID": undefined,
-  "geometry": {},
   "id": undefined,
   "labels": [
     {
@@ -111,7 +98,6 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 2`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {},
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;

--- a/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
+++ b/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
@@ -14,9 +14,10 @@ const balAddrToBanAddr = (
   const { addressID, mainTopoID, secondaryTopoIDs, districtID } = digestIDsFromBalAddr(balAdresse);
   const addrNumber = balAdresse.numero || oldBanAddress?.number;
   const positionType = convertBalPositionTypeToBanPositionType(balAdresse.position);
+  const suffix = balAdresse.suffixe
   const meta = balAdresse.cad_parcelles && balAdresse.cad_parcelles.length > 0 
     ? { cadastre: { ids: balAdresse.cad_parcelles } } 
-    : {}
+    : undefined;
   return addrNumber && addrNumber !== Number(IS_TOPO_NB)
     ? {
         ...(oldBanAddress || {}),
@@ -25,7 +26,6 @@ const balAddrToBanAddr = (
         mainCommonToponymID: mainTopoID,
         secondaryCommonToponymIDs: secondaryTopoIDs,
         number: addrNumber,
-        suffix: balAdresse.suffixe,
         positions: [
           // Previous positions
           ...(oldBanAddress?.positions || []),
@@ -39,7 +39,8 @@ const balAddrToBanAddr = (
         ],
         certified: balAdresse.certification_commune,
         updateDate: balAdresse.date_der_maj,
-        meta,
+        ...(suffix ? {suffix} : {}),
+        ...(meta ? {meta} : {}),
       }
     : undefined;
 };

--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
@@ -1,4 +1,4 @@
-import type { LangISO639v3 } from "../../types/ban-generic-types.js";
+import type { GeometryType, LangISO639v3 } from "../../types/ban-generic-types.js";
 import type { BalAdresse, VoieNomIsoCodeKey } from "../../types/bal-types.js";
 import type { BanCommonToponym } from "../../types/ban-types.js";
 
@@ -26,14 +26,14 @@ const balTopoToBanTopo = (
   const addrNumber = balAdresse.numero
   const meta = addrNumber === Number(IS_TOPO_NB) && balAdresse.cad_parcelles && balAdresse.cad_parcelles.length > 0 
     ? {cadastre: {ids: balAdresse.cad_parcelles}} 
-    : {}
+    : undefined
 
   const geometry = addrNumber === Number(IS_TOPO_NB) && balAdresse.long && balAdresse.lat 
     ? {
-      type: "Point",
-      coordinates: [balAdresse.long, balAdresse.lat],
+      type: 'Point' as GeometryType,
+      coordinates: [balAdresse.long, balAdresse.lat] as [number, number]
     }
-    : {}
+    : undefined
 
   return {
     ...(oldBanCommonToponym || {}),
@@ -43,9 +43,10 @@ const balTopoToBanTopo = (
       isoCode,
       value,
     })),
-    geometry,
+    
     updateDate: balAdresse.date_der_maj,
-    meta,
+    ...(geometry ? {geometry} : {}),
+    ...(meta ? {meta} : {}),
   };
 };
 

--- a/src/types/ban-generic-types.d.ts
+++ b/src/types/ban-generic-types.d.ts
@@ -15,3 +15,15 @@ export type PositionType =
   | "autre"; // TODO: update with more possible values OR Comply with the defined BAL Standard : https://aitf-sig-topo.github.io/voies-adresses/files/AITF_SIG_Topo_Format_Base_Adresse_Locale_v1.3.pdf
 export type DateISO8601 = Date;
 export type LangISO639v3 = string;
+export type Meta = {
+  [key: string]: any
+}
+export type Config = {
+  [key: string]: any
+}
+export type GeometryType = 'Point' // TODO: add other types
+export type Geometry = {
+  type: GeometryType;
+  coordinates: [number, number, number?];
+};
+

--- a/src/types/ban-types.d.ts
+++ b/src/types/ban-types.d.ts
@@ -5,16 +5,16 @@ import type {
   PositionType,
   DateISO8601,
   LangISO639v3,
+  Geometry,
+  Meta,
+  Config
 } from "./ban-generic-types.js";
 
 // TODO: use english names ?
 
 export type Position = {
   type: PositionType;
-  geometry: {
-    type: "Point";
-    coordinates: [number, number, number?];
-  };
+  geometry: Geometry
 };
 
 export type BanDistrict = {
@@ -24,15 +24,11 @@ export type BanDistrict = {
     value: string; // nom de la voie
   }[];
   updateDate: DateISO8601; // date de mise à jour de la commune
+  meta?: Meta;
+  config?: Config
 };
 
 export type BanDistricts = BanDistrict[];
-
-export type Meta = {
-  cadastre?:{
-    ids: string[];
-  }
-}
 
 export type BanCommonToponym = {
   id?: BanCommonTopoID; // identifiant unique de la voie
@@ -41,12 +37,9 @@ export type BanCommonToponym = {
     isoCode: LangISO639v3; // code ISO de la langue
     value: string; // nom de la voie
   }[];
-  geometry: {
-    type?: string;
-    coordinates?: number[];
-  };
+  geometry?: Geometry
   updateDate: DateISO8601; // date de mise à jour de la voie
-  meta: Meta
+  meta?: Meta
 };
 
 export type BanCommonToponyms = BanCommonToponym[];
@@ -61,7 +54,7 @@ export type BanAddress = {
   positions: Position[]; // positions géographiques de l'adresse
   certified?: boolean;
   updateDate: DateISO8601; // date de mise à jour de l'adresse
-  meta: Meta
+  meta?: Meta
 };
 
 export type BanAddresses = BanAddress[];


### PR DESCRIPTION
This PR aims to NOT send to ban API useless information such as default values for : 
- "meta" : if no meta information, the "meta" field won't be sent anymore.
- "geometry" : for addresses, geometry is required but for common toponyms, it is not. As a consequence, the "geometry" field won't be sent anymore if no data (ONLY common toponyms)
- "suffix" : for addresses, if no suffix information, the "suffix" field won't be sent anymore.