### PR TITLE
Added init bal into ban script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ npm install
 npm run dev
 ```
 
+## Scripts
+I. Init a BAL csv into the BAN plateforme using the ID-Fix BAL processing.
+
+Prerequisite : the district data of the BAL to import needs to be already present in the BAN DB. If not, use the POST /district api to create it.
+
+Here is the command to use : 
+```bash
+npm run initBALIntoBAN the/path/to/BAL/CSV
+```
+replace "the/path/to/BAL/CSV" to the actual path of the BAL csv to process and insert into the BAN
+
 ## License
 This project is licensed under the MIT License - see the LICENSE file for details.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npx tsc",
     "test": "vitest",
     "updateBAL": "ts-node --esm script/update-bal.ts",
+    "initBALIntoBAN": "ts-node --esm script/init-bal-into-ban.ts",
     "start": "node dist/app.js",
     "dev": "nodemon src/app.ts",
     "ts": "ts-node"

--- a/script/init-bal-into-ban.ts
+++ b/script/init-bal-into-ban.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env ts-node
+import 'dotenv/config.js';
+import fs from "node:fs";
+import path from "node:path";
+import argvParser from "minimist";
+import {
+  sendBalToBan
+} from "../src/bal-converter/index.js";
+import { exit } from "node:process";
+
+const args = argvParser(process.argv.slice(2));
+
+const {
+  _: [pathToBalCSVToInit],
+} = args;
+
+if (!pathToBalCSVToInit) {
+  console.error("Missing path to BAL CSV file");
+  exit(1);
+}
+
+if (!fs.existsSync(pathToBalCSVToInit)) {
+  console.error(`File '${pathToBalCSVToInit}' does not exist`);
+  exit(1);
+}
+
+if (!pathToBalCSVToInit.match(/\.csv$/)) {
+  console.error(`File '${pathToBalCSVToInit}' is not a CSV file`);
+  exit(1);
+}
+
+const mockBalCSV = fs.readFileSync(pathToBalCSVToInit, "utf8");
+
+await sendBalToBan(mockBalCSV);
+console.log(
+  `Data from '${path.basename(
+    pathToBalCSVToInit
+  )}' initialized in BAN DB`
+);


### PR DESCRIPTION
I. Context
In order to be able to initialized data from a BAL CSV into the BAN DB, this PR aims to add a cli script to read a local BAL CSV file and send it to ID-Fix processing. As a consequence, data is sent to BAN DB through the new BAN-ID APIs.

II. Enhancement
This PR adds the "initBALIntoBAN" cli script. To use it, use the command : 

`npm run initBALIntoBAN ${pathToBALCsv}`
(replace ${pathToBALCsv} by the path of the BAL CSV file to initialized)

example : 

`npm run initBALIntoBAN ${pathToBALCsv}`
