### PR TITLE
Added idRevision and dateRevision retrieval on bal district meta data

### DIFF
--- a/src/ban-api/index.ts
+++ b/src/ban-api/index.ts
@@ -182,3 +182,18 @@ export const getDistrictFromCOG = async (cog: string) => {
     throw new Error(`Ban API - ${message}`);
   }
 }
+
+export const partialUpdateDistricts = async (partialDistricts: any) => {
+  try {
+    const body = JSON.stringify(partialDistricts);
+    const response = await fetch(`${BAN_API_URL}/district`, {
+      method: "PATCH",
+      headers: defaultHeader,
+      body,
+    });
+    return await HandleHTTPResponse(response);
+  } catch (error) {
+    const { message } = error as Error;
+    throw new Error(`Ban API - ${message}`);
+  } 
+}


### PR DESCRIPTION
I. Context

We need to store the revision data (id and date) into the database when using id-fix.

II. Enhancement

This PR aims to add a district partial update (using newly added patch route) on "bal" meta field to add :
- idRevision <= `_id` field from the revision
- dateRevision <= `publishedAt` field from the revision