### PR TITLE
Added compute-from-cog/ route as a duplication of /district/cog/ route

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -10,6 +10,7 @@ import { getDistrictFromCOG, partialUpdateDistricts } from "./ban-api/index.js";
 
 const router: Router = Router();
 
+// This route has to be deleted when ban-plateforme will use the compute-from-cog/ route
 router.get(
   "/district/cog/:cog",
   authMiddleware,
@@ -53,8 +54,71 @@ router.get(
         logger.info(
           `District id ${id} update in BAN BDD. Response body : ${JSON.stringify(responseBody)}`,
         );
+      }
 
-        // TODO: Build Exploitation BDD (Legacy) from BAN BDD
+      response = {
+        date: new Date(),
+        status: "success",
+        response: responseBody,
+      };
+    } catch (error) {
+      const { message } = error as Error;
+      logger.error(message);
+      response = {
+        date: new Date(),
+        status: "error",
+        message,
+        response: {},
+      };
+    }
+
+    res.send(response);
+  }
+);
+
+router.get(
+  "compute-from-cog/:cog",
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    let response;
+    try {
+      let responseBody;
+      const { cog } = req.params;
+
+      const districtResponseRaw = await getDistrictFromCOG(cog);
+      if (!districtResponseRaw.length) {
+        throw new Error(`No district found with cog ${cog}`);
+      } else if (districtResponseRaw.length > 1) {
+        throw new Error(
+          `Multiple district found with cog ${cog}. Behavior not handled yet.`
+        );
+      }
+
+      const { id, config } = districtResponseRaw[0];
+      const useBanId = config?.useBanId;
+      if (!useBanId) {
+        throw new Error(`District id ${id} do not support BanID`);
+        // TODO: Build Exploitation BDD (Legacy) by Legacy compose
+      } else {
+        const revision = await getRevisionFromDistrictCOG(cog);
+        const revisionFileText = await getRevisionFileText(revision._id);
+
+        // Update District with revision data
+        const districtUpdate = {
+          id,
+          meta: {
+            bal: {
+              idRevision: revision._id,
+              dateRevision: revision.publishedAt,
+            },
+          },
+        };
+        await partialUpdateDistricts([districtUpdate]);
+
+        responseBody = (await sendBalToBan(revisionFileText)) || {};
+        logger.info(
+          `District id ${id} update in BAN BDD. Response body : ${JSON.stringify(responseBody)}`,
+        );
       }
 
       response = {


### PR DESCRIPTION
This pull request aims to rename the main id-fix route to something more relevant.
From `/district/cog/:cog` to `compute-from-cog/:cog`. To do the change progressively, the code of the route `/district/cog/:cog` has been duplicated to add the new route `compute-from-cog/:cog`

When ban-plateforme will use the new route `compute-from-cog/:cog` we need to deleted the old route `/district/cog/:cog`