### PR TITLE
Added check on ban id use for address id

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/check-if-bal-use-ban-id.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/check-if-bal-use-ban-id.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`balTopoToBanTopo > Should return false as bal does not have a common toponym ID on one of its line 1`] = `false`;
 
+exports[`balTopoToBanTopo > Should return false as bal does not have an address ID on one of its line that has a number different from the topo number 1`] = `false`;
+
 exports[`balTopoToBanTopo > Should return false as bal does not use ban IDs 1`] = `false`;
 
-exports[`balTopoToBanTopo > Should return true as bal uses ban IDs 1`] = `true`;
+exports[`balTopoToBanTopo > Should return true as bal 1.3 uses ban IDs 1`] = `true`;
+
+exports[`balTopoToBanTopo > Should return true as bal 1.4 uses ban IDs 1`] = `false`;

--- a/src/bal-converter/helpers/check-if-bal-use-ban-id.test.ts
+++ b/src/bal-converter/helpers/check-if-bal-use-ban-id.test.ts
@@ -2,30 +2,50 @@ import fs from "node:fs";
 import { describe, expect, test } from "vitest";
 import { checkIfBALUseBanId } from "./index.js";
 
-const pathToMockBalJSON = "./data-mock/adresses-21286_cocorico.json";
-const mockBalJSONstr = fs.readFileSync(pathToMockBalJSON, "utf8");
-const balJSON = JSON.parse(mockBalJSONstr);
-
 const pathToMockBalJSONlegacy =
   "./data-mock/adresses-21286_cocorico.legacy.json";
 const mockBalJSONlegacyStr = fs.readFileSync(pathToMockBalJSONlegacy, "utf8");
 const balJSONlegacy = JSON.parse(mockBalJSONlegacyStr);
 
+const pathToMockBalJSON_1 = "./data-mock/adresses-21286_cocorico.json";
+const mockBalJSONStr_1 = fs.readFileSync(pathToMockBalJSON_1, "utf8");
+const balJSON_1 = JSON.parse(mockBalJSONStr_1);
+
+const pathToMockBalJSON_2 = "./data-mock/adresses-21286_cocorico.1.4.json";
+const mockBalJSONStr_2 = fs.readFileSync(pathToMockBalJSON_2, "utf8");
+const balJSON_2 = JSON.parse(mockBalJSONStr_2);
+
 const banIDWhithoutCommonToponymID =
   "@c:e2b5c142-3eb3-4d07-830a-3d1a59195dfd @a:03fb190a-cf5b-4f48-a1ab-7caa4d10e157";
-const balJSONSimplifiedAndModified = [
+const balJSONSimplifiedAndModified_1 = [
   {
-    ...balJSON[0],
+    ...balJSON_1[0],
   },
   {
-    ...balJSON[1],
+    ...balJSON_1[1],
     uid_adresse: banIDWhithoutCommonToponymID,
   },
 ];
 
+const banIDWhithoutAddressID =
+  "@c:e2b5c142-3eb3-4d07-830a-3d1a59195dfd @v:787ca7cf-8072-47ae-a8c6-98a62a8dd90c";
+const balJSONSimplifiedAndModified_2 = [
+  {
+    ...balJSON_1[0],
+  },
+  {
+    ...balJSON_1[1],
+    uid_adresse: banIDWhithoutAddressID,
+  },
+];
+
 describe("balTopoToBanTopo", () => {
-  test("Should return true as bal uses ban IDs", async () => {
-    expect(checkIfBALUseBanId(balJSON)).toMatchSnapshot();
+  test("Should return true as bal 1.3 uses ban IDs", async () => {
+    expect(checkIfBALUseBanId(balJSON_1)).toMatchSnapshot();
+  });
+
+  test("Should return true as bal 1.4 uses ban IDs", async () => {
+    expect(checkIfBALUseBanId(balJSON_2)).toMatchSnapshot();
   });
 
   test("Should return false as bal does not use ban IDs", async () => {
@@ -33,6 +53,14 @@ describe("balTopoToBanTopo", () => {
   });
 
   test("Should return false as bal does not have a common toponym ID on one of its line", async () => {
-    expect(checkIfBALUseBanId(balJSONSimplifiedAndModified)).toMatchSnapshot();
+    expect(
+      checkIfBALUseBanId(balJSONSimplifiedAndModified_1)
+    ).toMatchSnapshot();
+  });
+
+  test("Should return false as bal does not have an address ID on one of its line that has a number different from the topo number", async () => {
+    expect(
+      checkIfBALUseBanId(balJSONSimplifiedAndModified_2)
+    ).toMatchSnapshot();
   });
 });

--- a/src/bal-converter/helpers/check-if-bal-use-ban-id.ts
+++ b/src/bal-converter/helpers/check-if-bal-use-ban-id.ts
@@ -1,11 +1,22 @@
 import { Bal, BalVersion } from "../../types/bal-types.js";
+import { logger } from "../../utils/logger.js";
 import { digestIDsFromBalAddr } from "./index.js";
+import { numberForTopo as IS_TOPO_NB } from "../bal-converter.config.js";
 
 const checkIfBALUseBanId = (bal: Bal, version?: BalVersion) => {
   let useBanId = true;
   for (const balAdresse of bal) {
-    const { mainTopoID } = digestIDsFromBalAddr(balAdresse, version);
-    if (!mainTopoID) {
+    const { districtID, mainTopoID, addressID } = digestIDsFromBalAddr(
+      balAdresse,
+      version
+    );
+    if (!districtID || !mainTopoID) {
+      useBanId = false;
+      break;
+    }
+    // If bal adresse line has a number (different from TOPO_NB), we need addressID to be defined too
+    if (balAdresse?.numero !== Number(IS_TOPO_NB) && !addressID) {
+      logger.info(`Missing addressID for bal address ${JSON.stringify(balAdresse)}`);
       useBanId = false;
       break;
     }


### PR DESCRIPTION
# Context
On ID-Fix, we are checking the use of the ban-ID (to activate or not the id-fix processing) on a BAL thanks to some criteria. For now, we are checking if each line has a main common toponym ID. 

# Enhancement
This PR aims to add a check on the BAL : 
- we check if there is a district ID on each line
- if a line is an address line (number different from 99_999), we check if there is an address ID
