### PR TITLE
Added trim operation on all values from bal

### DIFF
--- a/src/bal-converter/helpers/csv-bal-to-json-bal.ts
+++ b/src/bal-converter/helpers/csv-bal-to-json-bal.ts
@@ -8,25 +8,27 @@ const csvBalToJsonBal = (csv: string): Bal => {
     header: true,
     skipEmptyLines: true,
     transform: (value: string, headerName: string) => {
-      switch (headerName) {
+      const trimmedValue = value.trim();
+      const trimmedHeaderName = headerName.trim();
+      switch (trimmedHeaderName) {
         case "commune_insee":
         case "commune_deleguee_insee":
-          return value.trim() && value.padStart(5, "0");
+          return trimmedValue && trimmedValue.padStart(5, "0");
         case "numero":
-          return parseInt(value);
+          return parseInt(trimmedValue);
         case "x":
         case "y":
         case "long":
         case "lat":
-          return parseFloat(value);
+          return parseFloat(trimmedValue);
         case "certification_commune":
-          return value === "1";
+          return trimmedValue === "1";
         case "cad_parcelles":
-          return value !== "" ? value.split("|") : [];
+          return trimmedValue !== "" ? value.split("|") : [];
         case "date_der_maj":
-          return new Date(value);
+          return new Date(trimmedValue);
         default:
-          return value;
+          return trimmedValue;
       }
     },
   }).data as Bal;


### PR DESCRIPTION
# Context

On id-fix, when converting a bal from csv to json, we slightly transform some values (parseInt, parseFloat, ...).

# Enhancement

This PR adds a trim operation on all values from the BAL csv to solve empty string issues : 

<img width="869" alt="Capture d’écran 2024-01-17 à 11 45 00" src="https://github.com/BaseAdresseNationale/id-fix/assets/52679050/e053a7fc-f217-4538-98ba-aa2757b2f84b">
