### PR TITLE
Fix generate md5

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
@@ -8,11 +8,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID and BanTopoID 1`
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {
-    "idfix": {
-      "hash": "55450a7f0463128ae6cb77f5ae0410ae",
-    },
-  },
   "number": 1,
   "positions": [
     {
@@ -37,11 +32,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID without BanTopoI
   "districtID": undefined,
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": undefined,
-  "meta": {
-    "idfix": {
-      "hash": "dea5e71a883c27a7e2bbd4735d9de42a",
-    },
-  },
   "number": 1,
   "positions": [
     {
@@ -66,11 +56,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanID, BanTopoID, othe
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {
-    "idfix": {
-      "hash": "233f7091064934fa8a927b9a57d9d442",
-    },
-  },
   "number": 1,
   "positions": [
     {
@@ -99,11 +84,6 @@ exports[`balAddrToBanAddr > should return BanAddress with BanTopoID 1`] = `
   "districtID": undefined,
   "id": undefined,
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {
-    "idfix": {
-      "hash": "301cb59faadb7ef5fe8c877dfbf0923c",
-    },
-  },
   "number": 1,
   "positions": [
     {
@@ -128,11 +108,6 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
   "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
   "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
   "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
-  "meta": {
-    "idfix": {
-      "hash": "40dcdc9e0035670c043d043508f5175f",
-    },
-  },
   "number": 1,
   "positions": [
     {
@@ -171,11 +146,6 @@ exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1
   "districtID": undefined,
   "id": undefined,
   "mainCommonToponymID": undefined,
-  "meta": {
-    "idfix": {
-      "hash": "2bf856e5d03016e4f88548f656a44190",
-    },
-  },
   "number": 1,
   "positions": [
     {

--- a/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-to-ban.test.ts.snap
@@ -510,7 +510,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       "mainCommonToponymID": "c965715f-3874-4cba-ae4e-c9afa585f5eb",
       "meta": {
         "idfix": {
-          "hash": "a734076641a991aea8d01e55f8a7c009",
+          "hash": "78383f51f8416894ac2ffc48a85cf0ae",
         },
       },
       "number": 1,
@@ -889,7 +889,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       ],
       "meta": {
         "idfix": {
-          "hash": "0e6ef35cb7e62f389ef75accdcab09a2",
+          "hash": "32809e604e7b9b075c76d0fc2026abf1",
         },
       },
       "updateDate": "2021-09-06T00:00:00.000Z",
@@ -905,7 +905,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       ],
       "meta": {
         "idfix": {
-          "hash": "6948e3b029bd5e1750286bbc4e27a39b",
+          "hash": "e68f1b460899bb6c8ca383706884919c",
         },
       },
       "updateDate": "2021-09-06T00:00:00.000Z",
@@ -921,7 +921,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       ],
       "meta": {
         "idfix": {
-          "hash": "c1c7a987d818f7888973daf99a83f5a5",
+          "hash": "89fc16b5c1ba20eb526607e75b5ce126",
         },
       },
       "updateDate": "2021-09-06T00:00:00.000Z",
@@ -963,7 +963,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       ],
       "meta": {
         "idfix": {
-          "hash": "c16a000f57a31ab88e9a4fd223343738",
+          "hash": "fd9fd441060c0d5b20ede321c102ea15",
         },
       },
       "updateDate": "2021-09-06T00:00:00.000Z",
@@ -979,7 +979,7 @@ exports[`balToBan > should convert Bal list into Ban list 1`] = `
       ],
       "meta": {
         "idfix": {
-          "hash": "b554926f53d75252a0990d6712edbdb0",
+          "hash": "f75a1ac776fc54007779578b2eea7b7f",
         },
       },
       "updateDate": "2021-09-06T00:00:00.000Z",

--- a/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-topo-to-ban-topo.test.ts.snap
@@ -10,11 +10,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (1) 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "c6249c625f1c60373e85238cf92cc15e",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -29,11 +24,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID (2) 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "c6249c625f1c60373e85238cf92cc15e",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -48,11 +38,6 @@ exports[`balTopoToBanTopo > should return BanToponym with BanTopoID and BanDistr
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "c830bd351f23cf5c9d7553cfb96bec80",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -71,11 +56,6 @@ exports[`balTopoToBanTopo > should return BanToponym with multilingual label 1`]
       "value": "Baleen ibilbidea",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "ea0053807ccfac2e07b560674c3dae55",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -90,11 +70,6 @@ exports[`balTopoToBanTopo > should return BanToponym with overwrited data 1`] = 
       "value": "Avenue Rhoam Bosphoramus",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "2c256b9980c13169842b46209d757b76",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -109,11 +84,6 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 1`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "4293639f09ff774a7553810f47eceb1d",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;
@@ -128,11 +98,6 @@ exports[`balTopoToBanTopo > should return BanToponym without BanTopoID 2`] = `
       "value": "Route de la Baleine",
     },
   ],
-  "meta": {
-    "idfix": {
-      "hash": "4293639f09ff774a7553810f47eceb1d",
-    },
-  },
   "updateDate": 2021-01-01T00:00:00.000Z,
 }
 `;

--- a/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
+++ b/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
@@ -1,5 +1,3 @@
-import hash from "object-hash";
-
 import type { LangISO639v3 } from "../../types/ban-generic-types.js";
 import type {
   BalAdresse,
@@ -93,16 +91,6 @@ const balAddrToBanAddr = (
           ...(Object.keys(meta).length ? { meta } : {}),
         }
       : undefined;
-
-  // Store the md5 of the address to be able to compare it with the one in the BAN database
-  if (banAddress) {
-    banAddress.meta = {
-      ...meta,
-      idfix: {
-        hash: hash.MD5(banAddress),
-      },
-    };
-  }
 
   return banAddress;
 };

--- a/src/bal-converter/helpers/bal-to-ban.ts
+++ b/src/bal-converter/helpers/bal-to-ban.ts
@@ -1,5 +1,7 @@
-import type { Bal, BalAdresse } from "../../types/bal-types.js";
-import type { Ban } from "../../types/ban-types.js";
+import hash from "object-hash";
+
+import type { Bal } from "../../types/bal-types.js";
+import type { Ban, BanAddress, BanCommonToponym } from "../../types/ban-types.js";
 
 import balAddrToBanAddr from "./bal-addr-to-ban-addr.js";
 import balTopoToBanTopo from "./bal-topo-to-ban-topo.js";
@@ -42,6 +44,28 @@ const balToBan = (bal: Bal): Ban => {
       ban.commonToponyms[mainTopoID] = banCommonTopoIdContent;
     }
   }
+
+  // Store the md5 of the addresses
+  for (const address of Object.values(ban.addresses)) {
+    const itemHash = hash.MD5(address);
+    address.meta = {
+      ...address?.meta,
+      idfix: {
+        hash: itemHash,
+      },
+    };
+  };
+
+  // Store the md5 of the commonToponyms
+  for (const commonToponym of Object.values(ban.commonToponyms)) {
+    const itemHash = hash.MD5(commonToponym);
+    commonToponym.meta = {
+      ...commonToponym?.meta,
+      idfix: {
+        hash: itemHash,
+      },
+    };
+  };
 
   return ban;
 };

--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
@@ -1,5 +1,3 @@
-import hash from "object-hash";
-
 import type {
   GeometryType,
   LangISO639v3,
@@ -74,14 +72,6 @@ const balTopoToBanTopo = (
     updateDate: balAdresse.date_der_maj,
     ...(geometry ? { geometry } : {}),
     ...(Object.keys(meta).length ? { meta } : {}),
-  };
-
-  // Store the md5 of the common toponym to be able to compare it with the one in the BAN database
-  banCommonToponym.meta = {
-    ...meta,
-    idfix: {
-      hash: hash.MD5(banCommonToponym),
-    },
   };
 
   return banCommonToponym;


### PR DESCRIPTION
# Context 

Id-fix is processing a BAL. In the BAL format, multiple lines can represent the same entity : 
- an address : in a multi-position case
- a common toponym : when there are multiple address on a same street. 

There was an issue in the code when generating a hash on an entity in a multi line case. As a matter of fact, the hash was generated taking into account the previous hash generated on the previous line. 

# Enhancement 

This PR solve the issue on the hash generation in a multi line case (multi position on a address and mutli lines that represent a common toponym)