### PR TITLE
Fixed cad_parcelles array by trimming each values

### DIFF
--- a/src/bal-converter/helpers/csv-bal-to-json-bal.ts
+++ b/src/bal-converter/helpers/csv-bal-to-json-bal.ts
@@ -24,7 +24,7 @@ const csvBalToJsonBal = (csv: string): Bal => {
         case "certification_commune":
           return trimmedValue === "1";
         case "cad_parcelles":
-          return trimmedValue !== "" ? value.split("|") : [];
+          return trimmedValue !== "" ? value.split("|").map(value => value.trim()) : [];
         case "date_der_maj":
           return new Date(trimmedValue);
         default:


### PR DESCRIPTION
# Context 

When transforming the csv bal to a json bal, id-fix is processing the cad_parcelles so that : 
- the whole cad_parcelles cell is trimmed (example : `" 591183540AV0192 | 591183540AV0191 "` => `"591183540AV0192 | 591183540AV0191"`). 
- the resulted trimmed value is split by the pipe (= '|') separator to get an array of parcel ids (example : `"591183540AV0192 | 591183540AV0191"` => `["591183540AV0192 "," 591183540AV0191"]`

In this process, id-fix is not trimming again each of the array values.

# Enhancement 

This PR adds in the cad_parcelles processing from csv to json, the trimming of each value of the resulted parcel ids array.
In our example, it would result in : `["591183540AV0192 "," 591183540AV0191"]` => `["591183540AV0192","591183540AV0191"]`