### PR TITLE
Added mock for dump api importing local file instead

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,5 @@ BAN_API_URL=https://plateforme.adresse.data.gouv.fr/api
 BAN_API_TOKEN=
 BAN_LEGACY_API_TOKEN=
 API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
+STANDALONE_MODE=true
+PATH_TO_BAL_FILE=./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,6 @@ services:
       - BAN_API_TOKEN=${BAN_API_TOKEN}
       - API_DEPOT_URL=${API_DEPOT_URL}
       - BAN_LEGACY_API_TOKEN=${BAN_LEGACY_API_TOKEN}
+      - STANDALONE_MODE=${STANDALONE_MODE}
     ports:
       - "${PORT:-3000}:${PORT:-3000}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
+        "nock": "^14.0.0-beta.7",
         "nodemon": "^2.0.22",
         "prettier": "2.8.7",
         "ts-node": "^10.9.1",
@@ -3320,6 +3321,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -3616,6 +3623,19 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nock": {
+      "version": "14.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.7.tgz",
+      "integrity": "sha512-+EQMm5W9K8YnBE2Ceg4hnJynaCZmvK8ZlFXQ2fxGwtkOkBUq8GpQLTks2m1jpvse9XDxMDDOHgOWpiznFuh0bA==",
+      "dev": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/nodemon": {
@@ -4022,6 +4042,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -7589,6 +7618,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -7808,6 +7843,16 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "nock": {
+      "version": "14.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.7.tgz",
+      "integrity": "sha512-+EQMm5W9K8YnBE2Ceg4hnJynaCZmvK8ZlFXQ2fxGwtkOkBUq8GpQLTks2m1jpvse9XDxMDDOHgOWpiznFuh0bA==",
+      "dev": true,
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
     },
     "nodemon": {
       "version": "2.0.22",
@@ -8090,6 +8135,12 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
+    "nock": "^14.0.0-beta.7",
     "nodemon": "^2.0.22",
     "prettier": "2.8.7",
     "ts-node": "^10.9.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,23 @@
 import "dotenv/config.js";
 import express, { Application } from "express";
+import setupMocks from "./mock.js";
 import routes from "./routes.js";
+import { logger } from "./utils/logger.js";
 
 const PORT = process.env.PORT || 3000;
+const STANDALONE_MODE = process.env.STANDALONE_MODE === 'true' || false;
 
 // Initialize the Express application
 const app: Application = express();
 
 // Middleware to parse JSON requests
 app.use(express.json());
+
+// Apply mocks if in development mode
+if (STANDALONE_MODE) {
+  logger.info('Standalone mode : setting up mocks');
+  setupMocks(); // Call the mock setup function
+}
 
 // Define the API routes
 app.use("/", routes);

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,0 +1,37 @@
+import nock from "nock";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// Convert import.meta.url to __dirname equivalent
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const API_DEPOT_URL = process.env.API_DEPOT_URL || "";
+const PATH_TO_BAL_FILE = process.env.PATH_TO_BAL_FILE || "";
+
+const setupMocks = () => {
+  // Mocking dump API requests in development
+    nock(API_DEPOT_URL)
+      .get(/\/communes\/([^/]+)\/current-revision/)
+      .reply(200, (uri) => {
+        const match = uri.match(/\/communes\/([^/]+)\/current-revision/);
+        const cog = match ? match[1] : "unknown"; // Extract 'cog' from the URL
+        return {
+          _id: cog,
+          data: `Mocked data for COG ${cog}`,
+        };
+      });
+
+    nock(API_DEPOT_URL)
+    .get(/\/revisions\/([^/]+)\/files\/bal\/download/)
+    .reply(200, (uri) => {
+      const match = uri.match(/\/revisions\/([^/]+)\/files\/bal\/download/);
+      const cog = match ? match[1] : "unknown"; // Extract 'cog' from the URL
+        const localBalPath = path.resolve(__dirname, '../', PATH_TO_BAL_FILE, `bal-${cog}.csv`);
+        const localBal = readFileSync(localBalPath, 'utf-8');
+        return localBal;
+      });
+};
+
+export default setupMocks;


### PR DESCRIPTION
# Context

Id-fix has a strong dependency on a `api-de-dépôt`.

# Enhancement

This PR adds a `standalone` mode that is mocking the `api-de-dépôt` to be able to give a local BAL file. 
In order to do that, 
- a new boolean env parameter has been added : `STANDALONE_MODE` (=true/false),
- a new env parameter to target the BAL file : `PATH_TO_BAL_FILE` (absolute path from the root),
- the local BAL file has to be named `bal-${cog}.csv` (${cog} being the insee code of the desired BAL)