### PR TITLE
pas de libelle vide dans ban topo

### DIFF
--- a/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
+++ b/src/bal-converter/helpers/bal-topo-to-ban-topo.ts
@@ -67,7 +67,7 @@ const balTopoToBanTopo = (
     labels: Object.entries(labels).map(([isoCode, value]) => ({
       isoCode,
       value,
-    })),
+    })).filter(({value}) => value), // no empty value
 
     updateDate: balAdresse.date_der_maj,
     ...(geometry ? { geometry } : {}),


### PR DESCRIPTION
Dans la traduction de bal to ban, si l'élément est vide c'est qu'il n'existe pas : Ne pas le mettre dans le format ban.

lié avec le format/schema labelSchema ban-platform  lib/api/schema.js

exemple : https://plateforme-bal.adresse.data.gouv.fr/api-depot/revisions/668b98ef093891c55e5a3d92/files/bal/download
bal de bayonne ,
 le Giratoire Saint-Bernard , banid_topo 20bbc4d0-bfa3-4cc7-b72b-ea3c92cdd419
possede un voie_libelle mais pas de voie_libelle_eus


























































