### PR TITLE
Added check rules for district ID consistency and rights

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/validator.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/validator.test.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`balTopoToBanTopo > Should return false as bal does not use ban IDs 1`] = `false`;
+
+exports[`balTopoToBanTopo > Should return true as bal 1.3 uses ban IDs 1`] = `true`;
+
+exports[`balTopoToBanTopo > Should return true as bal 1.4 uses ban IDs 1`] = `true`;

--- a/src/bal-converter/helpers/index.ts
+++ b/src/bal-converter/helpers/index.ts
@@ -3,9 +3,9 @@ export { default as balJSONlegacy2balJSON } from "./bal-json-legacy-to-bal-json.
 export { default as convertBalPositionTypeToBanPositionType } from "./bal-position-type-to-ban-position-type.js";
 export { default as balToBan } from "./bal-to-ban.js";
 export { default as balTopoToBanTopo } from "./bal-topo-to-ban-topo.js";
-export { default as checkIfBALUseBanId } from "./check-if-bal-use-ban-id.js";
 export { default as csvBalToJsonBal } from "./csv-bal-to-json-bal.js";
 export { default as digestIDsFromBalAddr } from "./digest-ids-from-bal-addr.js";
 export { default as digestIDsFromBalUIDs } from "./digest-ids-from-bal-uids.js";
 export { default as jsonBalToCsvBal } from "./json-bal-to-csv-bal.js";
 export { default as getBalVersion } from "./get-bal-version.js";
+export { default as validator } from "./validator.js";


### PR DESCRIPTION
# Context 

For reinforcing BAL controls, id-fix is making some checks when receiving a BAL

# Enhancement

This PR adds checking rules on district ID : 
- Only 1 district ID in the received BAL. As a consequence, we ensure 1 BAL = 1 district ID = 1 cog 
- the district ID used in the BAL is the same as the district ID we have in our data base (so that we ensure that the district has the right to updates the addresses and toponyms linked to this district ID).

