### PR TITLE
Added 'to lower case' processing when retrieving ban ids

### DIFF
--- a/src/bal-converter/helpers/csv-bal-to-json-bal.ts
+++ b/src/bal-converter/helpers/csv-bal-to-json-bal.ts
@@ -27,6 +27,10 @@ const csvBalToJsonBal = (csv: string): Bal => {
           return trimmedValue !== "" ? value.split("|").map(value => value.trim()) : [];
         case "date_der_maj":
           return new Date(trimmedValue);
+        case "id_ban_commune":
+        case "id_ban_toponyme":
+        case "id_ban_adresse":
+          return trimmedValue.toLowerCase();
         default:
           return trimmedValue;
       }


### PR DESCRIPTION
# Context

An UUID is not case sensitive. It is valid and equivalent either it is in lower case and in upper case.

# Enchancement

This PR adds a formatting process when retrieving the ban ids from the BAL for the following columns : 
- id_ban_adresse
- id_ban_toponyme
- id_ban_commune