### PR TITLE
Handling multi-district

### DIFF
--- a/src/bal-converter/helpers/validator.test.ts
+++ b/src/bal-converter/helpers/validator.test.ts
@@ -81,50 +81,50 @@ const balWithDifferentDistrictID = [
 
 describe("balTopoToBanTopo", () => {
   test("Should return true as bal 1.3 uses ban IDs", async () => {
-    expect(await validator(districtID, balJSON_1, '1.3')).toMatchSnapshot();
+    expect(await validator([districtID], balJSON_1, '1.3')).toMatchSnapshot();
   });
 
   test("Should return true as bal 1.4 uses ban IDs", async () => {
-    expect(await validator(districtID, balJSON_2, '1.4')).toMatchSnapshot();
+    expect(await validator([districtID], balJSON_2, '1.4')).toMatchSnapshot();
   });
 
   test("Should return false as bal does not use ban IDs", async () => {
-    expect(await validator(districtID, balJSONlegacy, '1.3')).toMatchSnapshot();
+    expect(await validator([districtID], balJSONlegacy, '1.3')).toMatchSnapshot();
   });
 
   test("Should throw an error as bal does not have a district ID on one of its line", async () => {
     await expect(
-      validator(districtID, balJSONSimplifiedAndModified_1, '1.3')
+      validator([districtID], balJSONSimplifiedAndModified_1, '1.3')
     ).rejects.toThrowError(/Missing districtID/);
   });
 
   test("Should throw an error as bal does not have a common toponym ID on one of its line", async () => {
     await expect(
-      validator(districtID, balJSONSimplifiedAndModified_2, '1.3')
+      validator([districtID], balJSONSimplifiedAndModified_2, '1.3')
     ).rejects.toThrowError(/Missing mainTopoID/);
   });
 
   test("Should throw an error as bal does not have an address ID on one of its line that has a number different from the topo number", async () => {
     await expect(
-      validator(districtID, balJSONSimplifiedAndModified_3, '1.3')
+      validator([districtID], balJSONSimplifiedAndModified_3, '1.3')
     ).rejects.toThrowError(/Missing addressID/);
   });
 
   test("Should throw an error as some lines are using BanIDs and some are not", async () => {
     await expect(
-      validator(districtID, balJSONSimplifiedAndModified_4, '1.3')
+      validator([districtID], balJSONSimplifiedAndModified_4, '1.3')
     ).rejects.toThrowError(/Some lines are using BanIDs and some are not/);
   })
 
-  test("Should throw an error as multiple district IDs", async () => {
+  test("Should throw an error as one of district ID from BAL is not part of the authorized district ID", async () => {
     await expect(
-      validator(districtID, balWithMultipleDistrictIDs, '1.4')
-    ).rejects.toThrowError(/Multiple district IDs/);
+      validator([districtID], balWithMultipleDistrictIDs, '1.4')
+    ).rejects.toThrowError(/Missing rights/);
   })
 
   test("Should throw an error as district ID from BAL different from district ID from district DB", async () => {
     await expect(
-      validator(districtID, balWithDifferentDistrictID, '1.4')
+      validator([districtID], balWithDifferentDistrictID, '1.4')
     ).rejects.toThrowError(/Missing rights/);
   })
 });

--- a/src/compute-from-cog.ts
+++ b/src/compute-from-cog.ts
@@ -1,8 +1,7 @@
 // Get revision from dump-api (api de dépôt)
 import { logger } from "./utils/logger.js";
 import {
-  getRevisionFromDistrictCOG,
-  getRevisionFileText,
+  getRevisionData,
 } from "./dump-api/index.js";
 import { sendBalToBan } from "./bal-converter/index.js";
 import {
@@ -17,6 +16,8 @@ import {
 } from "./bal-converter/helpers/index.js";
 
 import acceptedCogList from "./accepted-cog-list.json" assert { type: "json" };
+import { BalAdresse } from "./types/bal-types.js";
+import { BanDistrict } from "./types/ban-types.js";
 
 export const computeFromCog = async (
   cog: string,
@@ -35,31 +36,27 @@ export const computeFromCog = async (
 
   logger.info(`District cog ${cog} is part of the whitelist.`);
 
-  const revision = await getRevisionFromDistrictCOG(cog);
-  const revisionFileText = await getRevisionFileText(revision._id);
-
+  // Get BAL text data from dump-api
+  const {revision, balTextData: balCsvData} = await getRevisionData(cog);
+  
   // Convert csv to json
-  const bal = csvBalToJsonBal(revisionFileText);
+  const bal = csvBalToJsonBal(balCsvData);
 
   // Detect BAL version
   const version = getBalVersion(bal);
   logger.info(`District cog ${cog} is using BAL version ${version}`);
 
-  const districtResponseRaw = await getDistrictFromCOG(cog);
-  if (!districtResponseRaw.length) {
+  const districts: BanDistrict[] = await getDistrictFromCOG(cog);
+  if (!districts.length) {
     throw new Error(`No district found with cog ${cog}`);
-  } else if (districtResponseRaw.length > 1) {
-    throw new Error(
-      `Multiple district found with cog ${cog}. Behavior not handled yet.`
-    );
   }
 
-  const { id } = districtResponseRaw[0];
+  const districtIDsFromDB = districts.map((district) => district.id);
 
   // Check if bal is using BanID
   // If not, send process to ban-plateforme legacy API
   // If the use of IDs is partial, throwing an error
-  const useBanId = await validator(id, bal, version);
+  const useBanId = await validator(districtIDsFromDB, bal, version);
 
   if (!useBanId) {
     logger.info(
@@ -68,32 +65,59 @@ export const computeFromCog = async (
     return await sendBalToLegacyCompose(cog, forceLegacyCompose as string);
   } else {
     logger.info(`District cog ${cog} is using banID`);
-    // Update District meta with revision data from dump-api (id and date)
-    const districtUpdate = {
-      id,
-      meta: {
-        bal: {
-          idRevision: revision._id,
-          dateRevision: revision.publishedAt,
-        },
+
+    // Split BAL by district ID to handle multiple districts in a BAL
+    const splitBalPerDistictID = bal.reduce(
+      (acc: { [key: string]: BalAdresse[] }, balAdresse) => {
+        if (balAdresse.id_ban_commune) {
+          if (!acc[balAdresse.id_ban_commune]) {
+            acc[balAdresse.id_ban_commune] = [];
+          }
+          acc[balAdresse.id_ban_commune].push(balAdresse);
+        }
+        return acc;
       },
-    };
-    await partialUpdateDistricts([districtUpdate]);
-
-    const result = (await sendBalToBan(bal)) || {};
-
-    if (!Object.keys(result).length) {
-      const response = `District id ${id} not updated in BAN BDD. No changes detected.`;
-      logger.info(response);
-      return response;
-    }
-
-    logger.info(
-      `District id ${id} updated in BAN BDD. Response body : ${JSON.stringify(
-        result
-      )}`
+      {}
     );
 
-    return result;
+    const results = [] 
+    for (let i = 0; i < Object.keys(splitBalPerDistictID).length; i++) {
+      const [id, bal] = Object.entries(splitBalPerDistictID)[i];
+      try {
+        // Update District meta with revision data from dump-api (id and date)
+        const districtUpdate = {
+          id,
+          meta: {
+            bal: {
+              idRevision: revision._id,
+              dateRevision: revision.publishedAt,
+            },
+          },
+        };
+        await partialUpdateDistricts([districtUpdate]);
+
+        const result = (await sendBalToBan(bal)) || {};
+
+        if (!Object.keys(result).length) {
+          const response = `District id ${id} (cog: ${cog}) not updated in BAN BDD. No changes detected.`;
+          logger.info(response);
+          return response;
+        }
+
+        logger.info(
+          `District id ${id} (cog: ${cog}) updated in BAN BDD. Response body : ${JSON.stringify(
+            result
+          )}`
+        );
+
+        results.push(result);
+      } catch (error) {
+        const { message } = error as Error;
+        logger.error(message);
+        results.push(`Error for district ${id} (cog: ${cog}) : ${message}`);
+      }
+    };
+
+    return results;
   }
 };

--- a/src/dump-api/index.ts
+++ b/src/dump-api/index.ts
@@ -2,7 +2,13 @@ import HandleHTTPResponse from "../utils/http-request-handler.js";
 
 const API_DEPOT_URL = process.env.API_DEPOT_URL || "";
 
-export const getRevisionFromDistrictCOG = async (cog: string) => {
+export const getRevisionData = async (cog: string) => {
+  const revision = await getRevisionFromDistrictCOG(cog);
+  const balTextData = await getRevisionFileText(revision._id);
+  return {revision, balTextData};
+}
+
+const getRevisionFromDistrictCOG = async (cog: string) => {
   try {
     const response = await fetch(
       `${API_DEPOT_URL}/communes/${cog}/current-revision`
@@ -14,7 +20,7 @@ export const getRevisionFromDistrictCOG = async (cog: string) => {
   }
 };
 
-export const getRevisionFileText = async (revisionId: string) => {
+const getRevisionFileText = async (revisionId: string) => {
   try {
     const response = await fetch(
       `${API_DEPOT_URL}/revisions/${revisionId}/files/bal/download`

--- a/src/types/ban-types.d.ts
+++ b/src/types/ban-types.d.ts
@@ -23,7 +23,7 @@ export type Label = {
 };
 
 export type BanDistrict = {
-  districtID: BanDistrictID; // code INSEE de la commune
+  id: BanDistrictID; // code INSEE de la commune
   labels: {
     isoCode: LangISO639v3; // code ISO de la langue
     value: string; // nom de la voie


### PR DESCRIPTION
# Context 

Currently, id-fix is handling 1 bal = 1 district. We would like id-fix to handle 1bal = multiple districts so that, when districts a merging ("fusion de communes") the district that sends its BAL could send it with addresses on the newly created district or on associated districts. This is a pre-requisite that is needed to be able to give to the districts the responsability to merge when they decide it.

# Enhancement

This PR adds the mechanism that : 
- checks the rights for multi-district BAL
- splits the BAL according to district IDs
- handles separately the split BAL