### PR TITLE
Added check to not update district when same revision id

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ BAN_LEGACY_API_TOKEN=
 API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 STANDALONE_MODE=true
 PATH_TO_BAL_FILE=./
+FORCE_REVISION=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,6 @@ services:
       - BAN_LEGACY_API_TOKEN=${BAN_LEGACY_API_TOKEN}
       - STANDALONE_MODE=${STANDALONE_MODE}
       - PATH_TO_BAL_FILE=${PATH_TO_BAL_FILE}
+      - FORCE_REVISION=${FORCE_REVISION:-false}
     ports:
       - "${PORT:-3000}:${PORT:-3000}"


### PR DESCRIPTION
# Context

Id-fix is currently updating the district meta with the revision data of the BAL sent even if the revision id is the same.

# Enchancement

This PR adds a check to : 
- not update district meta if revision id is the same as we have in the database

A new env variable `FORCE_REVISION` to override this check