### PR TITLE
Accepted address with number equal to 0

### DIFF
--- a/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
+++ b/src/bal-converter/helpers/__snapshots__/bal-addr-to-ban-addr.test.ts.snap
@@ -165,6 +165,39 @@ exports[`balAddrToBanAddr > should return BanAddress with multiple positions 1`]
 }
 `;
 
+exports[`balAddrToBanAddr > should return BanAddress with number '0' 1`] = `
+{
+  "certified": true,
+  "districtID": "dddddddd-0000-4aaa-9000-1234567890ff",
+  "id": "aaaaaaaa-0000-4aaa-9000-1234567890aa",
+  "mainCommonToponymID": "bbbbbbbb-0000-4aaa-9000-1234567890bb",
+  "meta": {
+    "bal": {
+      "cleInterop": "21286_0001_00001",
+    },
+  },
+  "number": 0,
+  "positions": [
+    {
+      "geometry": {
+        "coordinates": [
+          1,
+          2,
+        ],
+        "type": "Point",
+      },
+      "type": "entrance",
+    },
+  ],
+  "secondaryCommonToponymIDs": [
+    "cccccccc-0000-4aaa-9000-1234567890cc",
+    "cccccccc-1111-4aaa-9000-1234567890dd",
+    "cccccccc-2222-4aaa-9000-1234567890ee",
+  ],
+  "updateDate": 2021-01-01T00:00:00.000Z,
+}
+`;
+
 exports[`balAddrToBanAddr > should return BanAddress without BanID & BanTopoID 1`] = `
 {
   "certified": true,

--- a/src/bal-converter/helpers/bal-addr-to-ban-addr.test.ts
+++ b/src/bal-converter/helpers/bal-addr-to-ban-addr.test.ts
@@ -102,4 +102,14 @@ describe("balAddrToBanAddr", () => {
 
     expect(balAddrToBanAddr(testBalAddress, oldBanAddress)).toMatchSnapshot();
   });
+
+  test("should return BanAddress with number '0'", async () => {
+    const testBalAddress: BalAdresse = {
+      ...defaultTestBalAddress,
+      uid_adresse: idSampleWithAllIds,
+      numero: 0,
+    };
+
+    expect(balAddrToBanAddr(testBalAddress)).toMatchSnapshot();
+  });
 });

--- a/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
+++ b/src/bal-converter/helpers/bal-addr-to-ban-addr.ts
@@ -20,7 +20,7 @@ const balAddrToBanAddr = (
 ): BanAddress | undefined => {
   const { addressID, mainTopoID, secondaryTopoIDs, districtID } =
     digestIDsFromBalAddr(balAdresse, balVersion);
-  const addrNumber = balAdresse.numero || oldBanAddress?.number;
+  const addrNumber = balAdresse.numero ?? oldBanAddress?.number;
   const positionType = convertBalPositionTypeToBanPositionType(
     balAdresse.position
   );
@@ -60,8 +60,9 @@ const balAddrToBanAddr = (
       : {}),
     ...(Object.keys(balMeta).length ? { bal: balMeta } : {}),
   };
+
   const banAddress =
-    addrNumber && addrNumber !== Number(IS_TOPO_NB)
+    addrNumber !== undefined && addrNumber !== Number(IS_TOPO_NB)
       ? {
           ...(oldBanAddress || {}),
           id: addressID,
@@ -94,7 +95,7 @@ const balAddrToBanAddr = (
           ...(Object.keys(meta).length ? { meta } : {}),
         }
       : undefined;
-
+  
   return banAddress;
 };
 


### PR DESCRIPTION
# Context

Currently, id-fix does not retrieve an adresse line that have a number equal to 0

# Enhancement

This PR aims to accept and process an address that has a number equal to 0